### PR TITLE
Refactor BrewFlasher.com Integration

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -413,12 +413,12 @@ class NodeMcuFlasher(wx.Frame):
             self._config.device_family_string = ""
             self._config.device_family_id = None
             self._config.device_family_1200_bps = False
-            self.device_choice.SetItems(firmware_list.get_device_family_list(selected_project_id=self._config.project_id))
+            self.device_choice.SetItems([""] + firmware_list.get_device_family_list(selected_project_id=self._config.project_id))
 
             # reset the firmware items
             self._config.firmware_string = ""
             self._config.firmware_obj = None
-            self.firmware_choice.SetItems(firmware_list.get_firmware_list(selected_project_id=self._config.project_id))
+            self.firmware_choice.SetItems([""] + firmware_list.get_firmware_list(selected_project_id=self._config.project_id))
 
         def on_select_device_family(event):
             choice = event.GetEventObject()
@@ -434,8 +434,8 @@ class NodeMcuFlasher(wx.Frame):
             # reset the firmware items
             self._config.firmware_string = ""
             self._config.firmware_obj = None
-            self.firmware_choice.SetItems(firmware_list.get_firmware_list(selected_project_id=self._config.project_id,
-                                                                          selected_family_id=self._config.device_family_id))
+            self.firmware_choice.SetItems([""] + firmware_list.get_firmware_list(selected_project_id=self._config.project_id,
+                                                                                 selected_family_id=self._config.device_family_id))
 
         def on_select_firmware(event):
             choice = event.GetEventObject()
@@ -464,15 +464,14 @@ class NodeMcuFlasher(wx.Frame):
         reload_button.Bind(wx.EVT_BUTTON, on_reload)
         reload_button.SetToolTip(_("Reload serial device list"))
 
-        self.project_choice = wx.Choice(panel, choices=firmware_list.get_project_list())
+        self.project_choice = wx.Choice(panel, choices=([""] + firmware_list.get_project_list()))
         self.project_choice.Bind(wx.EVT_CHOICE, on_select_project)
 
-        self.device_choice = wx.Choice(panel, choices=firmware_list.get_device_family_list())
+        self.device_choice = wx.Choice(panel, choices=([""] + firmware_list.get_device_family_list()))
         self.device_choice.Bind(wx.EVT_CHOICE, on_select_device_family)
 
-        self.firmware_choice = wx.Choice(panel, choices=firmware_list.get_firmware_list())
+        self.firmware_choice = wx.Choice(panel, choices=([""] + firmware_list.get_firmware_list()))
         self.firmware_choice.Bind(wx.EVT_CHOICE, on_select_firmware)
-
 
         serial_boxsizer = wx.BoxSizer(wx.HORIZONTAL)
         serial_boxsizer.Add(self.choice, 1, wx.EXPAND)

--- a/Main.py
+++ b/Main.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import subprocess
+from shutil import which
 from time import sleep
 
 import serial
@@ -83,6 +85,12 @@ __version__ = "1.6.0"
 __auto_select__ = _("Auto-select")
 __auto_select_explanation__ = _("(first port with Espressif device)")
 __supported_baud_rates__ = [9600, 57600, 74880, 115200, 230400, 460800, 921600]
+
+def check_for_avrdude() -> bool:
+    if which("avrdude") is not None or which("avrdude.exe") is not None:
+        return True
+    else:
+        return False
 
 # ---------------------------------------------------------------------------
 
@@ -254,7 +262,8 @@ class FlashingThread(threading.Thread):
                 sleep(0.1)
                 ser = serial.Serial(self._config.port, baudrate=1200, timeout=5, write_timeout=0)
                 sleep(1.5)
-                print("...done\n")
+                print(_("...done"))
+                print("")
                 ser.close()
             except SerialException as e:
                 # sleep(0.1)
@@ -370,6 +379,11 @@ class NodeMcuFlasher(wx.Frame):
         print(_("Connect your device"))
         print("")
         print(_("If you chose the serial port auto-select feature you might need to turn off Bluetooth"))
+
+        if not check_for_avrdude():
+            print("")
+            print(_("Avrdude was not found. Arduino firmware cannot be flashed."))
+            print(_("To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"))
 
     def _init_ui(self):
         def on_reload(event):

--- a/Main.py
+++ b/Main.py
@@ -122,6 +122,162 @@ class RedirectText:
 # ---------------------------------------------------------------------------
 
 
+def flash_firmware_using_whatever_is_appropriate(firmware_obj: brewflasher_com_integration.Firmware, baud:str, serial_port:str, erase_before_flash:bool) -> bool:
+    # Initial checks
+    if firmware_obj.family is None or firmware_obj is None:
+        print(_("Must select the project, device family, and firmware to flash before flashing."))
+        return False
+
+    print(_("Verifying firmware list is up-to-date before downloading..."))
+    if not firmware_obj.pre_flash_web_verify(brewflasher_version=__version__):
+        print(_("Firmware list is not up to date.") + " " + _("Relaunch BrewFlasher and try again."))
+        return False
+
+    print(_("Downloading firmware..."))
+    if not firmware_obj.download_to_file():
+        print(_("Error - unable to download firmware.\n"))
+        return False
+    print(_("Downloaded successfully!\n"))
+
+    if firmware_obj.family.flash_method == "esptool":
+        # Construct the command based on device family
+        device_name = firmware_obj.family.name
+        command_extension = []
+
+        if device_name in ["ESP32", "ESP32-S2", "ESP32-C3"]:
+            flash_options = {
+                "ESP32": ["esp32", "0x10000"],
+                "ESP32-S2": ["esp32s2", "-z", "--flash_mode", "dio", "--flash_freq", "80m", "0x10000"],
+                "ESP32-C3": ["esp32c3", "-z", "--flash_mode", "dio", "--flash_freq", "80m", "0x10000"]
+            }
+            command_extension.extend(["--chip", flash_options[device_name][0], "--baud", str(baud),
+                                      "--before", "default_reset", "--after", "hard_reset", "write_flash"])
+            command_extension.extend(flash_options[device_name][1:])
+            command_extension.append(firmware_obj.full_filepath("firmware"))
+
+            if firmware_obj.download_url_partitions and firmware_obj.checksum_partitions:
+                command_extension.extend(["0x8000", firmware_obj.full_filepath("partitions")])
+
+            if firmware_obj.family.download_url_bootloader and firmware_obj.family.checksum_bootloader:
+                boot_address = "0x0" if device_name == "ESP32-C3" else "0x1000"
+                command_extension.extend([boot_address, firmware_obj.full_filepath("bootloader")])
+
+        elif device_name == "ESP8266":
+            command_extension.extend(["--chip", "esp8266", "write_flash", "0x00000",
+                                      firmware_obj.full_filepath("firmware")])
+        else:
+            print(_("Invalid device family detected.") + " " + _("Relaunch BrewFlasher and try again."))
+            return False
+
+        # For both ESP32 and ESP8266 we can directly flash an image to SPIFFS/LittleFS/OTAData
+        if firmware_obj.download_url_spiffs and firmware_obj.checksum_spiffs and len(firmware_obj.spiffs_address) > 2:
+            command_extension.append(firmware_obj.spiffs_address)
+            command_extension.append(firmware_obj.full_filepath("spiffs"))
+
+        if (firmware_obj.family.download_url_otadata and firmware_obj.family.checksum_otadata and
+                len(firmware_obj.family.otadata_address) > 2):
+            # We need to flash the otadata section. The location is dependent on the partition scheme
+            command_extension.append(firmware_obj.family.otadata_address)
+            command_extension.append(firmware_obj.full_filepath("otadata"))
+
+        # Construct the main command
+        if not serial_port.startswith(__auto_select__):
+            # Explicitly select the serial port
+            command = ["--port", serial_port] + command_extension
+        elif firmware_obj.family.use_1200_bps_touch:
+            # For some reason, this code never executes (at least on Mac OS)
+            print(_("ERROR - Cannot automatically select the serial port for this device family. Please explicitly "
+                    "select the correct device to continue."))
+            return False
+        else:
+            # For autoselect, we just leave off the serial port (at least for ESP devices)
+            command = command_extension
+
+        if erase_before_flash:
+            command.extend(["--erase-all"])
+
+        # There is a breaking change in esptool 3.0 that changes the flash size from detect to keep. We want to
+        # support "detect" by default.
+        command.extend(["-fs", "detect"])
+
+        print(f"Esptool command: esptool.py {' '.join(command)}\n")
+
+    elif firmware_obj.family.flash_method == "avrdude":
+        # if serial_port.startswith(__auto_select__):
+        #     print(_("ERROR - Cannot automatically select the serial port for this device family. Please explicitly "
+        #             "select the correct device to continue."))
+        #     return False
+
+        command = [
+            "avrdude",
+            "-p", "atmega328p",
+            "-c", "arduino",
+            "-P", serial_port,
+            "-D",  # Disable auto erase - may want to make this configurable in the future
+            "-U", f"flash:w:{firmware_obj.full_filepath('firmware')}:i"
+        ]
+
+        print("Avrdude command: avrdude %s\n" % " ".join(command))
+
+    else:
+        raise ValueError(_("Invalid flash method detected. Update BrewFlasher and try again."))
+
+    # Handle 1200 bps touch for certain devices
+    if firmware_obj.family.use_1200_bps_touch:
+        try:
+            sleep(0.1)
+            print(_("Performing 1200 bps touch"))
+            with serial.Serial(serial_port, baudrate=1200, timeout=5, write_timeout=0) as ser:
+                sleep(1.5)
+                print(_("...done"))
+                print("")
+        except SerialException as e:
+            sleep(0.1)
+            print(_("...unable to perform 1200bps touch."))
+
+            print("")
+            print(_("Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."))
+            print("")
+            print(_("Alternatively, you may need to manually set the device into 'flash' mode."))
+            print("")
+            print(_("For instructions on how to do this, check this website:\nhttp://www.brewflasher.com/manualflash/"))
+            raise e
+
+    try:
+        if firmware_obj.family.flash_method == "esptool":
+            esptool.main(command)
+        elif firmware_obj.family.flash_method == "avrdude":
+            results = subprocess.run(command, capture_output=True)
+            if results.returncode != 0:
+                print(results.stderr.decode("utf-8"))
+                print(_("Firmware flashing FAILED. {tool} raised an error.").format(
+                    tool=firmware_obj.family.flash_method))
+                print("")
+                print(_("Try flashing again, or try flashing with a slower speed."))
+                print("")
+                return False
+    except SerialException as e:
+        sleep(0.1)
+        raise e
+    except Exception as e:
+        sleep(0.1)
+        print(_("Firmware flashing FAILED. {tool} raised an error.").format(tool=firmware_obj.family.flash_method))
+        print("")
+        print(_("Try flashing again, or try flashing with a slower speed."))
+        print("")
+        if firmware_obj.family.use_1200_bps_touch:
+            print("")
+            print(_("Alternatively, you may need to manually set the device into 'flash' mode."))
+            print("")
+            print(_("For instructions on how to do this, check this website:\nhttp://www.brewflasher.com/manualflash/"))
+        return False
+
+    # The last line printed by esptool is "Staying in bootloader." -> some indication that the process is
+    # done is needed
+    print("")
+    print(_("Firmware successfully flashed. Reset device to switch back to normal boot mode."))
+
+
 # ---------------------------------------------------------------------------
 class FlashingThread(threading.Thread):
     def __init__(self, parent, config):
@@ -131,181 +287,9 @@ class FlashingThread(threading.Thread):
         self._config = config
 
     def run(self):
-        command = []
+        flash_firmware_using_whatever_is_appropriate(self._config.firmware_obj, str(self._config.baud),
+                                                     self._config.port, self._config.erase_before_flash)
 
-        # Fermentrack-specific config options
-        if self._config.project_string == "" or  self._config.project_id is None:
-            print(_("Must select the project, device family, and firmware to flash before flashing."))
-            return
-        if self._config.device_family_string == "" or self._config.device_family_id is None:
-            print(_("Must select the project, device family, and firmware to flash before flashing."))
-            return
-        if self._config.firmware_string == "" or self._config.firmware_obj is None:
-            print(_("Must select the project, device family, and firmware to flash before flashing."))
-            return
-
-        print(_("Verifying firmware list is up-to-date before downloading..."))
-        if not self._config.firmware_obj.pre_flash_web_verify(brewflasher_version=__version__):
-            print(_("Firmware list is not up to date.") + " " + _("Relaunch BrewFlasher and try again."))
-            return
-
-        print(_("Downloading firmware..."))
-        device_family = firmware_list.DeviceFamilies[self._config.firmware_obj.family_id]
-        if self._config.firmware_obj.download_to_file():
-            print(_("Downloaded successfully!\n"))
-        else:
-            print(_("Error - unable to download firmware.\n"))
-            return
-
-        if self._config.device_family_string == "ESP32" or self._config.device_family_string == "ESP32-S2" or \
-                self._config.device_family_string == "ESP32-C3":
-            if self._config.device_family_string == "ESP32":
-                # This command matches the ESP32 flash options JSON from BrewFlasher.com
-                command_extension = ["--chip", "esp32",
-                                     "--baud", str(self._config.baud),
-                                     "--before", "default_reset", "--after", "hard_reset",
-                                     "write_flash",  "0x10000",
-                                     self._config.firmware_obj.full_filepath("firmware")]
-            elif self._config.device_family_string == "ESP32-S2":
-                # This command matches the ESP32-S2 flash options JSON from BrewFlasher.com
-                command_extension = ["--chip", "esp32s2",
-                                     "--baud", str(self._config.baud),
-                                     "--before", "default_reset", "--after", "hard_reset",
-                                     "write_flash", "-z", "--flash_mode", "dio", "--flash_freq", "80m",
-                                     "0x10000",
-                                     self._config.firmware_obj.full_filepath("firmware")]
-            elif self._config.device_family_string == "ESP32-C3":
-                # This command matches the ESP32-C3 flash options JSON from BrewFlasher.com
-                command_extension = ["--chip", "esp32c3",
-                                     "--baud", str(self._config.baud),
-                                     "--before", "default_reset", "--after", "hard_reset",
-                                     "write_flash", "-z", "--flash_mode", "dio", "--flash_freq", "80m",
-                                     "0x10000",
-                                     self._config.firmware_obj.full_filepath("firmware")]
-            else:
-                print(_("Invalid device family detected.") + " " + _("Relaunch BrewFlasher and try again."))
-                return
-
-            # For the ESP32, we can flash a custom partition table if we need it. If this firmware template involves
-            # flashing a partition table, lets add that to the flash request
-            if len(self._config.firmware_obj.download_url_partitions) > 0 and len(
-                    self._config.firmware_obj.checksum_partitions) > 0:
-                command_extension.append("0x8000")
-                command_extension.append(self._config.firmware_obj.full_filepath("partitions"))
-
-            # For now, I'm assuming bootloader flashing is ESP32 only
-            if len(device_family.download_url_bootloader) > 0 and \
-                    len(device_family.checksum_bootloader) > 0:
-                if self._config.device_family_string == "ESP32-C3":
-                    command_extension.append("0x0")
-                else:
-                    command_extension.append("0x1000")
-                command_extension.append(self._config.firmware_obj.full_filepath("bootloader"))
-
-        elif self._config.device_family_string == "ESP8266":
-            command_extension = ["--chip", "esp8266",
-                                 "write_flash",
-                                 # "--flash_mode", self._config.mode,
-                                 "0x00000",
-                                 self._config.firmware_obj.full_filepath("firmware")]
-        else:
-            print(_("Invalid device family detected.") + " " + _("Relaunch BrewFlasher and try again."))
-            return
-
-        # For both ESP32 and ESP8266 we can directly flash an image to SPIFFS/LittleFS
-        if len(self._config.firmware_obj.download_url_spiffs) > 0 and \
-                len(self._config.firmware_obj.checksum_spiffs) > 0 and \
-                len(self._config.firmware_obj.spiffs_address) > 2:
-            # We need to flash SPIFFS. The location is dependent on the partition scheme
-            command_extension.append(self._config.firmware_obj.spiffs_address)
-            command_extension.append(self._config.firmware_obj.full_filepath("spiffs"))
-
-        # For both ESP32 and ESP8266 we can directly flash an image to the otadata section
-        if len(device_family.download_url_otadata) > 0 and \
-                len(device_family.checksum_otadata) > 0 and \
-                len(device_family.otadata_address) > 2:
-            # We need to flash the otadata section. The location is dependent on the partition scheme
-            command_extension.append(device_family.otadata_address)
-            command_extension.append(self._config.firmware_obj.full_filepath("otadata"))
-
-        if not self._config.port.startswith(__auto_select__):
-            command.append("--port")
-            command.append(self._config.port)
-        elif self._config.device_family_1200_bps:
-            # For some reason, this code never executes (at least on Mac OS)
-            print(_("ERROR - Cannot automatically select the serial port for this device family. Please explicitly "
-                  "select the correct device to continue."))
-            return
-
-        # command.extend(["--baud", str(self._config.baud),
-        #                 "--after", "no_reset",
-        #                 "write_flash",
-        #                 "--flash_mode", self._config.mode,
-        #                 "0x00000", self._config.firmware_path])
-        command.extend(command_extension)
-
-        if self._config.erase_before_flash:
-            command.append("--erase-all")
-
-        # There is a breaking change in esptool 3.0 that changes the flash size from detect to keep. We want to
-        # support "detect" by default.
-        command.append("-fs")
-        command.append("detect")
-
-        # For certain devices (such as the ESP32-S2) there is a requirement that we open a brief connection to the
-        # controller at 1200bps to signal to the controller that it should set itself into a flashable state. We do
-        # this using basic pyserial, as esptool doesn't have this functionality built in.
-        if self._config.device_family_1200_bps:
-            try:
-                sleep(0.1)
-                print(_("Performing 1200 bps touch"))
-                sleep(0.1)
-                ser = serial.Serial(self._config.port, baudrate=1200, timeout=5, write_timeout=0)
-                sleep(1.5)
-                print(_("...done"))
-                print("")
-                ser.close()
-            except SerialException as e:
-                # sleep(0.1)
-                # self._parent.report_error(e.strerror)
-                sleep(0.1)
-                print(_("...unable to perform 1200bps touch."))
-
-                print("")
-                print(_("Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."))
-                print("")
-                print(_("Alternatively, you may need to manually set the device into 'flash' mode."))
-                print("")
-                print(_("For instructions on how to do this, check this website:\nhttp://www.brewflasher.com/manualflash/"))
-                raise e
-
-        print("Command: esptool.py %s\n" % " ".join(command))
-
-        try:
-            esptool.main(command)
-        except SerialException as e:
-            sleep(0.1)
-            self._parent.report_error(e.strerror)
-            raise e
-        except Exception as e:
-            sleep(0.1)
-            print(_("Firmware flashing FAILED. esptool.py raised an error."))
-            print("")
-            print(_("Try flashing again, or try flashing with a slower speed."))
-            print("")
-            if self._config.device_family_1200_bps:
-                print("")
-                print(_("Alternatively, you may need to manually set the device into 'flash' mode."))
-                print("")
-                print(_("For instructions on how to do this, check this website:\nhttp://www.brewflasher.com/manualflash/"))
-            # sleep(0.1)
-            # sentry_sdk.capture_exception(e)
-            return
-
-        # The last line printed by esptool is "Staying in bootloader." -> some indication that the process is
-        # done is needed
-        print("")
-        print(_("Firmware successfully flashed. Reset device to switch back to normal boot mode."))
 
 
 # ---------------------------------------------------------------------------
@@ -676,7 +660,7 @@ class MySplashScreen(wx.adv.SplashScreen):
                                      wx.adv.SPLASH_CENTRE_ON_SCREEN | wx.adv.SPLASH_TIMEOUT, 2500, None, -1)
         self.Bind(wx.EVT_CLOSE, self._on_close)
         # TODO - Rewrite the splash function so as to actually do this in the background
-        firmware_list.load_from_website()
+        firmware_list.load_from_website(False)
         self.__fc = wx.CallLater(2000, self._show_main)
 
     def _on_close(self, evt):

--- a/Main.py
+++ b/Main.py
@@ -143,7 +143,7 @@ class FlashingThread(threading.Thread):
 
         print(_("Downloading firmware..."))
         device_family = firmware_list.DeviceFamilies[self._config.firmware_obj.family_id]
-        if self._config.firmware_obj.download_to_file(device_family=device_family):
+        if self._config.firmware_obj.download_to_file():
             print(_("Downloaded successfully!\n"))
         else:
             print(_("Error - unable to download firmware.\n"))

--- a/Main.py
+++ b/Main.py
@@ -129,7 +129,7 @@ def flash_firmware_using_whatever_is_appropriate(firmware_obj: brewflasher_com_i
         return False
 
     print(_("Verifying firmware list is up-to-date before downloading..."))
-    if not firmware_obj.pre_flash_web_verify(brewflasher_version=__version__):
+    if not firmware_obj.pre_flash_web_verify(brewflasher_version=__version__, flasher="BrewFlasher"):
         print(_("Firmware list is not up to date.") + " " + _("Relaunch BrewFlasher and try again."))
         return False
 

--- a/brewflasher_com_integration.py
+++ b/brewflasher_com_integration.py
@@ -118,8 +118,8 @@ class Firmware:
             cur_filepath = os.path.dirname(os.path.realpath(__file__))
         return os.path.join(cur_filepath, bintype + ".bin")
 
-    def download_to_file(self, device_family, check_checksum=True, force_download=False):
-        # If this is a multi-part firmware (ESP32, with partitions or SPIFFS) then download the additional parts.
+    def download_to_file(self, check_checksum: bool = True, force_download: bool = False):
+        # If this is a multipart firmware (e.g. ESP32, with partitions or SPIFFS) then download the additional parts.
         if len(self.download_url_partitions) > 12:
             print("Downloading partitions file...")
             if not self.download_file(self.full_filepath("partitions"), self.download_url_partitions,
@@ -134,17 +134,17 @@ class Firmware:
                 print("Error downloading SPIFFS/LittleFS file!")
                 return False
 
-        if len(device_family.download_url_bootloader) > 12:
+        if len(self.family.download_url_bootloader) > 12:
             print("Downloading bootloader file...")
-            if not self.download_file(self.full_filepath("bootloader"), device_family.download_url_bootloader,
-                                      device_family.checksum_bootloader, check_checksum, force_download):
+            if not self.download_file(self.full_filepath("bootloader"), self.family.download_url_bootloader,
+                                      self.family.checksum_bootloader, check_checksum, force_download):
                 print("Error downloading bootloader file!")
                 return False
 
-        if len(device_family.download_url_otadata) > 12 and len(device_family.otadata_address) > 2:
+        if len(self.family.download_url_otadata) > 12 and len(self.family.otadata_address) > 2:
             print("Downloading otadata file...")
-            if not self.download_file(self.full_filepath("otadata"), device_family.download_url_otadata,
-                                      device_family.checksum_otadata, check_checksum, force_download):
+            if not self.download_file(self.full_filepath("otadata"), self.family.download_url_otadata,
+                                      self.family.checksum_otadata, check_checksum, force_download):
                 print("Error downloading otadata file!")
                 return False
 

--- a/brewflasher_com_integration.py
+++ b/brewflasher_com_integration.py
@@ -10,6 +10,26 @@ BREWFLASHER_COM_URL = "https://www.brewflasher.com/firmware"
 MODEL_VERSION = 3
 
 
+class DeviceFamily:
+    def __init__(self, name="", flash_method="", id=0, detection_family="", use_1200_bps_touch=False,
+                 download_url_bootloader="", download_url_otadata="", otadata_address="", checksum_bootloader="",
+                 checksum_otadata=""):
+        self.name = name
+        self.flash_method = flash_method
+        self.detection_family = detection_family
+        self.id = id
+        self.firmware = []
+        self.use_1200_bps_touch = use_1200_bps_touch
+        self.download_url_bootloader = download_url_bootloader
+        self.download_url_otadata = download_url_otadata
+        self.otadata_address = otadata_address
+        self.checksum_bootloader = checksum_bootloader
+        self.checksum_otadata = checksum_otadata
+
+    def __str__(self):
+        return self.name
+
+
 class Project:
     def __init__(self, name="", weight=0, description="", support_url="", id=0, project_url="", documentation_url="",
                  show=""):
@@ -153,24 +173,6 @@ class Firmware:
         return False
 
 
-class DeviceFamily:
-    def __init__(self, name="", flash_method="", id=0, detection_family="", use_1200_bps_touch=False,
-                 download_url_bootloader="", download_url_otadata="", otadata_address="", checksum_bootloader="",
-                 checksum_otadata=""):
-        self.name = name
-        self.flash_method = flash_method
-        self.detection_family = detection_family
-        self.id = id
-        self.firmware = []
-        self.use_1200_bps_touch = use_1200_bps_touch
-        self.download_url_bootloader = download_url_bootloader
-        self.download_url_otadata = download_url_otadata
-        self.otadata_address = otadata_address
-        self.checksum_bootloader = checksum_bootloader
-        self.checksum_otadata = checksum_otadata
-
-    def __str__(self):
-        return self.name
 
 
 # FirmwareList is intended as a singleton
@@ -373,7 +375,7 @@ class FirmwareList:
         if family_id not in self.Projects[project_id].device_families:
             # The family_id was invalid  - Return None
             return None
-        # Iterate throuh the list of firmware to find the appropriate one
+        # Iterate through the list of firmware to find the appropriate one
         for this_firmware in self.Projects[project_id].device_families[family_id].firmware:
             if str(this_firmware) == firmware_str:
                 return this_firmware

--- a/brewflasher_com_integration.py
+++ b/brewflasher_com_integration.py
@@ -153,11 +153,11 @@ class Firmware:
         return self.download_file(self.full_filepath("firmware"), self.download_url, self.checksum, check_checksum,
                                   force_download)
 
-    def pre_flash_web_verify(self, brewflasher_version):
+    def pre_flash_web_verify(self, brewflasher_version, flasher="BrewFlasher"):
         """Recheck that the checksum we have cached is still the one that brewflasher.com reports"""
         request_dict = {
             'firmware_id': self.id,
-            'flasher': "BrewFlasher",
+            'flasher': flasher,
             'flasher_version': brewflasher_version
         }
         url = BREWFLASHER_COM_URL + "/api/flash_verify/"
@@ -167,6 +167,15 @@ class Firmware:
             if response['message'] == self.checksum:
                 return True
         return False
+
+    def remove_downloaded_firmware(self):
+        """Delete the downloaded firmware files"""
+
+        firmware_types = ["bootloader", "firmware", "partitions", "spiffs", "otadata"]
+
+        for firmware_type in firmware_types:
+            if os.path.exists(self.full_filepath(firmware_type)):
+                os.remove(self.full_filepath(firmware_type))
 
 
 @dataclass

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #rm -fr build dist
-#VERSION=1.5.2
+#VERSION=1.6.0
 #NAME=BrewFlasher
 
 source ./venv/bin/activate

--- a/locales/brewflasher.po
+++ b/locales/brewflasher.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-11 21:29-0400\n"
+"POT-Creation-Date: 2023-08-11 22:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,165 +25,165 @@ msgstr ""
 msgid "(first port with Espressif device)"
 msgstr ""
 
-#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
+#: Main.py:128
 msgid ""
 "Must select the project, device family, and firmware to flash before "
 "flashing."
 msgstr ""
 
-#: Main.py:130 Main.py:278
+#: Main.py:131
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr ""
 
-#: Main.py:132 Main.py:280
+#: Main.py:133
 msgid "Firmware list is not up to date."
 msgstr ""
 
-#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
+#: Main.py:133 Main.py:169
 msgid "Relaunch BrewFlasher and try again."
 msgstr ""
 
-#: Main.py:135 Main.py:283
+#: Main.py:136
 msgid "Downloading firmware..."
 msgstr ""
 
-#: Main.py:137 Main.py:288
+#: Main.py:138
 msgid "Error - unable to download firmware.\n"
 msgstr ""
 
-#: Main.py:139 Main.py:286
+#: Main.py:140
 msgid "Downloaded successfully!\n"
 msgstr ""
 
-#: Main.py:168 Main.py:317 Main.py:343
+#: Main.py:169
 msgid "Invalid device family detected."
 msgstr ""
 
-#: Main.py:206
-msgid "Invalid flash method detected. Update BrewFlasher and try again."
-msgstr ""
-
-#: Main.py:212 Main.py:392
-msgid "Performing 1200 bps touch"
-msgstr ""
-
-#: Main.py:215 Main.py:396
-msgid "...done"
-msgstr ""
-
-#: Main.py:219 Main.py:403
-msgid "...unable to perform 1200bps touch."
-msgstr ""
-
-#: Main.py:222 Main.py:406
-msgid ""
-"Make sure you have selected the correct serial port (auto-select will not"
-" work for this chip) and try again."
-msgstr ""
-
-#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
-msgid "Alternatively, you may need to manually set the device into 'flash' mode."
-msgstr ""
-
-#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
-msgid ""
-"For instructions on how to do this, check this website:\n"
-"http://www.brewflasher.com/manualflash/"
-msgstr ""
-
-#: Main.py:239 Main.py:423
-msgid "Firmware flashing FAILED. esptool.py raised an error."
-msgstr ""
-
-#: Main.py:241 Main.py:425
-msgid "Try flashing again, or try flashing with a slower speed."
-msgstr ""
-
-#: Main.py:253 Main.py:439
-msgid ""
-"Firmware successfully flashed. Reset device to switch back to normal boot"
-" mode."
-msgstr ""
-
-#: Main.py:367
+#: Main.py:189
 msgid ""
 "ERROR - Cannot automatically select the serial port for this device "
 "family. Please explicitly select the correct device to continue."
 msgstr ""
 
-#: Main.py:510
+#: Main.py:223
+msgid "Invalid flash method detected. Update BrewFlasher and try again."
+msgstr ""
+
+#: Main.py:229
+msgid "Performing 1200 bps touch"
+msgstr ""
+
+#: Main.py:232
+msgid "...done"
+msgstr ""
+
+#: Main.py:236
+msgid "...unable to perform 1200bps touch."
+msgstr ""
+
+#: Main.py:239
+msgid ""
+"Make sure you have selected the correct serial port (auto-select will not"
+" work for this chip) and try again."
+msgstr ""
+
+#: Main.py:241 Main.py:262
+msgid "Alternatively, you may need to manually set the device into 'flash' mode."
+msgstr ""
+
+#: Main.py:243 Main.py:264
+msgid ""
+"For instructions on how to do this, check this website:\n"
+"http://www.brewflasher.com/manualflash/"
+msgstr ""
+
+#: Main.py:256
+msgid "Firmware flashing FAILED. {tool} raised an error."
+msgstr ""
+
+#: Main.py:258
+msgid "Try flashing again, or try flashing with a slower speed."
+msgstr ""
+
+#: Main.py:270
+msgid ""
+"Firmware successfully flashed. Reset device to switch back to normal boot"
+" mode."
+msgstr ""
+
+#: Main.py:355
 msgid "Connect your device"
 msgstr ""
 
-#: Main.py:512
+#: Main.py:357
 msgid ""
 "If you chose the serial port auto-select feature you might need to turn "
 "off Bluetooth"
 msgstr ""
 
-#: Main.py:516
+#: Main.py:361
 msgid "Avrdude was not found. Arduino firmware cannot be flashed."
 msgstr ""
 
-#: Main.py:517
+#: Main.py:362
 msgid ""
 "To install Avrdude, follow the instructions at "
 "https://github.com/avrdudes/avrdude/"
 msgstr ""
 
-#: Main.py:610
+#: Main.py:455
 msgid "Reload serial device list"
 msgstr ""
 
-#: Main.py:678
+#: Main.py:523
 msgid "no"
 msgstr ""
 
-#: Main.py:679
+#: Main.py:524
 msgid "yes, wipes all data"
 msgstr ""
 
-#: Main.py:681
+#: Main.py:526
 msgid "Download Firmware and Flash Controller"
 msgstr ""
 
-#: Main.py:691
+#: Main.py:536
 msgid "Serial port"
 msgstr ""
 
-#: Main.py:692
+#: Main.py:537
 msgid "Project"
 msgstr ""
 
-#: Main.py:693
+#: Main.py:538
 msgid "Device Family"
 msgstr ""
 
-#: Main.py:694
+#: Main.py:539
 msgid "Firmware"
 msgstr ""
 
-#: Main.py:695
+#: Main.py:540
 msgid "Baud rate"
 msgstr ""
 
-#: Main.py:717
+#: Main.py:562
 msgid "Erase flash"
 msgstr ""
 
-#: Main.py:718
+#: Main.py:563
 msgid "Console"
 msgstr ""
 
-#: Main.py:756
+#: Main.py:601
 msgid "Welcome to BrewFlasher {version}"
 msgstr ""
 
-#: Main.py:766
+#: Main.py:611
 msgid "Exit BrewFlasher"
 msgstr ""
 
-#: Main.py:773
+#: Main.py:618
 msgid "About"
 msgstr ""
 

--- a/locales/brewflasher.po
+++ b/locales/brewflasher.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-10 20:18-0400\n"
+"POT-Creation-Date: 2023-08-11 21:29-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,157 +25,165 @@ msgstr ""
 msgid "(first port with Espressif device)"
 msgstr ""
 
-#: Main.py:138 Main.py:141 Main.py:144
+#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
 msgid ""
 "Must select the project, device family, and firmware to flash before "
 "flashing."
 msgstr ""
 
-#: Main.py:147
+#: Main.py:130 Main.py:278
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr ""
 
-#: Main.py:149
+#: Main.py:132 Main.py:280
 msgid "Firmware list is not up to date."
 msgstr ""
 
-#: Main.py:149 Main.py:190 Main.py:216 Main.py:342
+#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
 msgid "Relaunch BrewFlasher and try again."
 msgstr ""
 
-#: Main.py:152
+#: Main.py:135 Main.py:283
 msgid "Downloading firmware..."
 msgstr ""
 
-#: Main.py:155
-msgid "Downloaded successfully!\n"
-msgstr ""
-
-#: Main.py:157
+#: Main.py:137 Main.py:288
 msgid "Error - unable to download firmware.\n"
 msgstr ""
 
-#: Main.py:190 Main.py:216 Main.py:342
+#: Main.py:139 Main.py:286
+msgid "Downloaded successfully!\n"
+msgstr ""
+
+#: Main.py:168 Main.py:317 Main.py:343
 msgid "Invalid device family detected."
 msgstr ""
 
-#: Main.py:240
-msgid ""
-"ERROR - Cannot automatically select the serial port for this device "
-"family. Please explicitly select the correct device to continue."
+#: Main.py:206
+msgid "Invalid flash method detected. Update BrewFlasher and try again."
 msgstr ""
 
-#: Main.py:265
+#: Main.py:212 Main.py:392
 msgid "Performing 1200 bps touch"
 msgstr ""
 
-#: Main.py:275
+#: Main.py:215 Main.py:396
+msgid "...done"
+msgstr ""
+
+#: Main.py:219 Main.py:403
 msgid "...unable to perform 1200bps touch."
 msgstr ""
 
-#: Main.py:278
+#: Main.py:222 Main.py:406
 msgid ""
 "Make sure you have selected the correct serial port (auto-select will not"
 " work for this chip) and try again."
 msgstr ""
 
-#: Main.py:280 Main.py:301 Main.py:334
+#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr ""
 
-#: Main.py:282 Main.py:303 Main.py:336
+#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
 msgid ""
 "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr ""
 
-#: Main.py:295 Main.py:328
+#: Main.py:239 Main.py:423
 msgid "Firmware flashing FAILED. esptool.py raised an error."
 msgstr ""
 
-#: Main.py:297 Main.py:330
+#: Main.py:241 Main.py:425
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr ""
 
-#: Main.py:312 Main.py:425
-msgid "Avrdude was not found. Arduino firmware cannot be flashed."
-msgstr ""
-
-#: Main.py:313 Main.py:426
-msgid ""
-"To install Avrdude, follow the instructions at "
-"https://github.com/avrdudes/avrdude/"
-msgstr ""
-
-#: Main.py:347
+#: Main.py:253 Main.py:439
 msgid ""
 "Firmware successfully flashed. Reset device to switch back to normal boot"
 " mode."
 msgstr ""
 
-#: Main.py:419
+#: Main.py:367
+msgid ""
+"ERROR - Cannot automatically select the serial port for this device "
+"family. Please explicitly select the correct device to continue."
+msgstr ""
+
+#: Main.py:510
 msgid "Connect your device"
 msgstr ""
 
-#: Main.py:421
+#: Main.py:512
 msgid ""
 "If you chose the serial port auto-select feature you might need to turn "
 "off Bluetooth"
 msgstr ""
 
-#: Main.py:525
-msgid "Reload serial device list"
+#: Main.py:516
+msgid "Avrdude was not found. Arduino firmware cannot be flashed."
 msgstr ""
 
-#: Main.py:597
-msgid "no"
-msgstr ""
-
-#: Main.py:598
-msgid "yes, wipes all data"
-msgstr ""
-
-#: Main.py:600
-msgid "Download Firmware and Flash Controller"
+#: Main.py:517
+msgid ""
+"To install Avrdude, follow the instructions at "
+"https://github.com/avrdudes/avrdude/"
 msgstr ""
 
 #: Main.py:610
+msgid "Reload serial device list"
+msgstr ""
+
+#: Main.py:678
+msgid "no"
+msgstr ""
+
+#: Main.py:679
+msgid "yes, wipes all data"
+msgstr ""
+
+#: Main.py:681
+msgid "Download Firmware and Flash Controller"
+msgstr ""
+
+#: Main.py:691
 msgid "Serial port"
 msgstr ""
 
-#: Main.py:611
+#: Main.py:692
 msgid "Project"
 msgstr ""
 
-#: Main.py:612
+#: Main.py:693
 msgid "Device Family"
 msgstr ""
 
-#: Main.py:613
+#: Main.py:694
 msgid "Firmware"
 msgstr ""
 
-#: Main.py:614
+#: Main.py:695
 msgid "Baud rate"
 msgstr ""
 
-#: Main.py:636
+#: Main.py:717
 msgid "Erase flash"
 msgstr ""
 
-#: Main.py:637
+#: Main.py:718
 msgid "Console"
 msgstr ""
 
-#: Main.py:675
+#: Main.py:756
 msgid "Welcome to BrewFlasher {version}"
 msgstr ""
 
-#: Main.py:685
+#: Main.py:766
 msgid "Exit BrewFlasher"
 msgstr ""
 
-#: Main.py:692
+#: Main.py:773
 msgid "About"
 msgstr ""
 

--- a/locales/de/LC_MESSAGES/brewflasher.po
+++ b/locales/de/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-10 20:18-0400\n"
-"PO-Revision-Date: 2023-08-11 01:01\n"
+"POT-Creation-Date: 2023-08-11 21:29-0400\n"
+"PO-Revision-Date: 2023-08-12 01:43\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
@@ -26,145 +26,153 @@ msgstr "Automatisch auswählen"
 msgid "(first port with Espressif device)"
 msgstr "(erster Port mit Espressif-Gerät)"
 
-#: Main.py:138 Main.py:141 Main.py:144
+#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Projekt, Gerätefamilie und Firmware müssen vor dem Flashen ausgewählt werden."
 
-#: Main.py:147
+#: Main.py:130 Main.py:278
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Überprüfe die Firmware-Liste, bevor der Download startet..."
 
-#: Main.py:149
+#: Main.py:132 Main.py:280
 msgid "Firmware list is not up to date."
 msgstr "Firmware-Liste ist nicht aktuell."
 
-#: Main.py:149 Main.py:190 Main.py:216 Main.py:342
+#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Starte BrewFlasher neu und versuche es erneut."
 
-#: Main.py:152
+#: Main.py:135 Main.py:283
 msgid "Downloading firmware..."
 msgstr "Firmware wird heruntergeladen..."
 
-#: Main.py:155
-msgid "Downloaded successfully!\n"
-msgstr "Download abgeschlossen!\n"
-
-#: Main.py:157
+#: Main.py:137 Main.py:288
 msgid "Error - unable to download firmware.\n"
 msgstr "Fehler - Firmware kann nicht heruntergeladen werden.\n"
 
-#: Main.py:190 Main.py:216 Main.py:342
+#: Main.py:139 Main.py:286
+msgid "Downloaded successfully!\n"
+msgstr "Download abgeschlossen!\n"
+
+#: Main.py:168 Main.py:317 Main.py:343
 msgid "Invalid device family detected."
 msgstr "Gerätefamilie nicht unterstützt."
 
-#: Main.py:240
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "FEHLER – Die serielle Schnittstelle für diese Gerätefamilie konnte nicht automatisch erkannt werden. Wählen Sie das korrekte Gerät aus, um fortzufahren."
+#: Main.py:206
+msgid "Invalid flash method detected. Update BrewFlasher and try again."
+msgstr "Ungültige Flash-Methode erkannt. Aktualisieren Sie BrewFlasher und versuchen Sie es erneut."
 
-#: Main.py:265
+#: Main.py:212 Main.py:392
 msgid "Performing 1200 bps touch"
 msgstr "1200 Bit/s Ping wird ausgeführt"
 
-#: Main.py:275
+#: Main.py:215 Main.py:396
+msgid "...done"
+msgstr "...fertig"
+
+#: Main.py:219 Main.py:403
 msgid "...unable to perform 1200bps touch."
 msgstr "...1200 Bit/s Ping konnte nicht ausgeführt werden."
 
-#: Main.py:278
+#: Main.py:222 Main.py:406
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Stellen Sie sicher, dass Sie den richtigen seriellen Port ausgewählt haben (automatische Auswahl funktioniert nicht für diesen Chip) und versuchen Sie es erneut."
 
-#: Main.py:280 Main.py:301 Main.py:334
+#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternativ müssen sie das Gerät in den Flash-Modus ändern."
 
-#: Main.py:282 Main.py:303 Main.py:336
+#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "Für Anweisungen, wie man dies macht, ist diese Website hilfreich:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:295 Main.py:328
+#: Main.py:239 Main.py:423
 msgid "Firmware flashing FAILED. esptool.py raised an error."
 msgstr "Firmware Flash fehlgeschlagen. esptool.py meldet einen Fehler."
 
-#: Main.py:297 Main.py:330
+#: Main.py:241 Main.py:425
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Versuch den Flash nochmal, oder Flashe mit einer langsameren Geschwindigkeit."
 
-#: Main.py:312 Main.py:425
-msgid "Avrdude was not found. Arduino firmware cannot be flashed."
-msgstr "Avrdude wurde nicht gefunden. Arduino-Firmware kann nicht geflasht werden."
-
-#: Main.py:313 Main.py:426
-msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
-msgstr "Um Avrdude zu installieren, folgen Sie den Anweisungen unter https://github.com/avrdudes/avrdude/"
-
-#: Main.py:347
+#: Main.py:253 Main.py:439
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware erfolgreich geflasht. Starte das Gerät neu, um zum normalen Boot-Modus zurückzukehren."
 
-#: Main.py:419
+#: Main.py:367
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "FEHLER – Die serielle Schnittstelle für diese Gerätefamilie konnte nicht automatisch erkannt werden. Wählen Sie das korrekte Gerät aus, um fortzufahren."
+
+#: Main.py:510
 msgid "Connect your device"
 msgstr "Verbinde das Gerät"
 
-#: Main.py:421
+#: Main.py:512
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Wenn Sie die automatische Auswahl der seriellen Schnittstelle ausgewählt haben, muss Bluetooth möglicherweise deaktiviert sein"
 
-#: Main.py:525
+#: Main.py:516
+msgid "Avrdude was not found. Arduino firmware cannot be flashed."
+msgstr "Avrdude wurde nicht gefunden. Arduino-Firmware kann nicht geflasht werden."
+
+#: Main.py:517
+msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
+msgstr "Um Avrdude zu installieren, folgen Sie den Anweisungen unter https://github.com/avrdudes/avrdude/"
+
+#: Main.py:610
 msgid "Reload serial device list"
 msgstr "Schnittstellengeräteliste neu laden"
 
-#: Main.py:597
+#: Main.py:678
 msgid "no"
 msgstr "Nein"
 
-#: Main.py:598
+#: Main.py:679
 msgid "yes, wipes all data"
 msgstr "Ja (alle Daten werden gelöscht)"
 
-#: Main.py:600
+#: Main.py:681
 msgid "Download Firmware and Flash Controller"
 msgstr "Firmware und Flash-Controller herunterladen"
 
-#: Main.py:610
+#: Main.py:691
 msgid "Serial port"
 msgstr "Serielle Schnittstelle"
 
-#: Main.py:611
+#: Main.py:692
 msgid "Project"
 msgstr "Projekt"
 
-#: Main.py:612
+#: Main.py:693
 msgid "Device Family"
 msgstr "Gerätefamilie"
 
-#: Main.py:613
+#: Main.py:694
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:614
+#: Main.py:695
 msgid "Baud rate"
 msgstr "Baudrate"
 
-#: Main.py:636
+#: Main.py:717
 msgid "Erase flash"
 msgstr "Flash löschen"
 
-#: Main.py:637
+#: Main.py:718
 msgid "Console"
 msgstr "Konsole"
 
-#: Main.py:675
+#: Main.py:756
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Willkommen zu BrewFlasher {version}"
 
-#: Main.py:685
+#: Main.py:766
 msgid "Exit BrewFlasher"
 msgstr "BrewFlasher beenden"
 
-#: Main.py:692
+#: Main.py:773
 msgid "About"
 msgstr "Info"
 

--- a/locales/de/LC_MESSAGES/brewflasher.po
+++ b/locales/de/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-11 21:29-0400\n"
-"PO-Revision-Date: 2023-08-12 01:43\n"
+"POT-Creation-Date: 2023-08-11 22:41-0400\n"
+"PO-Revision-Date: 2023-08-12 02:41\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
@@ -26,153 +26,153 @@ msgstr "Automatisch auswählen"
 msgid "(first port with Espressif device)"
 msgstr "(erster Port mit Espressif-Gerät)"
 
-#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
+#: Main.py:128
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Projekt, Gerätefamilie und Firmware müssen vor dem Flashen ausgewählt werden."
 
-#: Main.py:130 Main.py:278
+#: Main.py:131
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Überprüfe die Firmware-Liste, bevor der Download startet..."
 
-#: Main.py:132 Main.py:280
+#: Main.py:133
 msgid "Firmware list is not up to date."
 msgstr "Firmware-Liste ist nicht aktuell."
 
-#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
+#: Main.py:133 Main.py:169
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Starte BrewFlasher neu und versuche es erneut."
 
-#: Main.py:135 Main.py:283
+#: Main.py:136
 msgid "Downloading firmware..."
 msgstr "Firmware wird heruntergeladen..."
 
-#: Main.py:137 Main.py:288
+#: Main.py:138
 msgid "Error - unable to download firmware.\n"
 msgstr "Fehler - Firmware kann nicht heruntergeladen werden.\n"
 
-#: Main.py:139 Main.py:286
+#: Main.py:140
 msgid "Downloaded successfully!\n"
 msgstr "Download abgeschlossen!\n"
 
-#: Main.py:168 Main.py:317 Main.py:343
+#: Main.py:169
 msgid "Invalid device family detected."
 msgstr "Gerätefamilie nicht unterstützt."
 
-#: Main.py:206
+#: Main.py:189
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "FEHLER – Die serielle Schnittstelle für diese Gerätefamilie konnte nicht automatisch erkannt werden. Wählen Sie das korrekte Gerät aus, um fortzufahren."
+
+#: Main.py:223
 msgid "Invalid flash method detected. Update BrewFlasher and try again."
 msgstr "Ungültige Flash-Methode erkannt. Aktualisieren Sie BrewFlasher und versuchen Sie es erneut."
 
-#: Main.py:212 Main.py:392
+#: Main.py:229
 msgid "Performing 1200 bps touch"
 msgstr "1200 Bit/s Ping wird ausgeführt"
 
-#: Main.py:215 Main.py:396
+#: Main.py:232
 msgid "...done"
 msgstr "...fertig"
 
-#: Main.py:219 Main.py:403
+#: Main.py:236
 msgid "...unable to perform 1200bps touch."
 msgstr "...1200 Bit/s Ping konnte nicht ausgeführt werden."
 
-#: Main.py:222 Main.py:406
+#: Main.py:239
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Stellen Sie sicher, dass Sie den richtigen seriellen Port ausgewählt haben (automatische Auswahl funktioniert nicht für diesen Chip) und versuchen Sie es erneut."
 
-#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
+#: Main.py:241 Main.py:262
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternativ müssen sie das Gerät in den Flash-Modus ändern."
 
-#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
+#: Main.py:243 Main.py:264
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "Für Anweisungen, wie man dies macht, ist diese Website hilfreich:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:239 Main.py:423
-msgid "Firmware flashing FAILED. esptool.py raised an error."
-msgstr "Firmware Flash fehlgeschlagen. esptool.py meldet einen Fehler."
+#: Main.py:256
+msgid "Firmware flashing FAILED. {tool} raised an error."
+msgstr "Firmware Flash fehlgeschlagen. {tool} meldet einen Fehler."
 
-#: Main.py:241 Main.py:425
+#: Main.py:258
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Versuch den Flash nochmal, oder Flashe mit einer langsameren Geschwindigkeit."
 
-#: Main.py:253 Main.py:439
+#: Main.py:270
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware erfolgreich geflasht. Starte das Gerät neu, um zum normalen Boot-Modus zurückzukehren."
 
-#: Main.py:367
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "FEHLER – Die serielle Schnittstelle für diese Gerätefamilie konnte nicht automatisch erkannt werden. Wählen Sie das korrekte Gerät aus, um fortzufahren."
-
-#: Main.py:510
+#: Main.py:355
 msgid "Connect your device"
 msgstr "Verbinde das Gerät"
 
-#: Main.py:512
+#: Main.py:357
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Wenn Sie die automatische Auswahl der seriellen Schnittstelle ausgewählt haben, muss Bluetooth möglicherweise deaktiviert sein"
 
-#: Main.py:516
+#: Main.py:361
 msgid "Avrdude was not found. Arduino firmware cannot be flashed."
 msgstr "Avrdude wurde nicht gefunden. Arduino-Firmware kann nicht geflasht werden."
 
-#: Main.py:517
+#: Main.py:362
 msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
 msgstr "Um Avrdude zu installieren, folgen Sie den Anweisungen unter https://github.com/avrdudes/avrdude/"
 
-#: Main.py:610
+#: Main.py:455
 msgid "Reload serial device list"
 msgstr "Schnittstellengeräteliste neu laden"
 
-#: Main.py:678
+#: Main.py:523
 msgid "no"
 msgstr "Nein"
 
-#: Main.py:679
+#: Main.py:524
 msgid "yes, wipes all data"
 msgstr "Ja (alle Daten werden gelöscht)"
 
-#: Main.py:681
+#: Main.py:526
 msgid "Download Firmware and Flash Controller"
 msgstr "Firmware und Flash-Controller herunterladen"
 
-#: Main.py:691
+#: Main.py:536
 msgid "Serial port"
 msgstr "Serielle Schnittstelle"
 
-#: Main.py:692
+#: Main.py:537
 msgid "Project"
 msgstr "Projekt"
 
-#: Main.py:693
+#: Main.py:538
 msgid "Device Family"
 msgstr "Gerätefamilie"
 
-#: Main.py:694
+#: Main.py:539
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:695
+#: Main.py:540
 msgid "Baud rate"
 msgstr "Baudrate"
 
-#: Main.py:717
+#: Main.py:562
 msgid "Erase flash"
 msgstr "Flash löschen"
 
-#: Main.py:718
+#: Main.py:563
 msgid "Console"
 msgstr "Konsole"
 
-#: Main.py:756
+#: Main.py:601
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Willkommen zu BrewFlasher {version}"
 
-#: Main.py:766
+#: Main.py:611
 msgid "Exit BrewFlasher"
 msgstr "BrewFlasher beenden"
 
-#: Main.py:773
+#: Main.py:618
 msgid "About"
 msgstr "Info"
 

--- a/locales/en/LC_MESSAGES/brewflasher.po
+++ b/locales/en/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-10 20:18-0400\n"
-"PO-Revision-Date: 2023-08-11 01:01\n"
+"POT-Creation-Date: 2023-08-11 21:29-0400\n"
+"PO-Revision-Date: 2023-08-12 01:43\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
 "MIME-Version: 1.0\n"
@@ -26,145 +26,153 @@ msgstr "Auto-select"
 msgid "(first port with Espressif device)"
 msgstr "(first port with Espressif device)"
 
-#: Main.py:138 Main.py:141 Main.py:144
+#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Must select the project, device family, and firmware to flash before flashing."
 
-#: Main.py:147
+#: Main.py:130 Main.py:278
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verifying firmware list is up-to-date before downloading..."
 
-#: Main.py:149
+#: Main.py:132 Main.py:280
 msgid "Firmware list is not up to date."
 msgstr "Firmware list is not up to date."
 
-#: Main.py:149 Main.py:190 Main.py:216 Main.py:342
+#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Relaunch BrewFlasher and try again."
 
-#: Main.py:152
+#: Main.py:135 Main.py:283
 msgid "Downloading firmware..."
 msgstr "Downloading firmware..."
 
-#: Main.py:155
-msgid "Downloaded successfully!\n"
-msgstr "Downloaded successfully!\n"
-
-#: Main.py:157
+#: Main.py:137 Main.py:288
 msgid "Error - unable to download firmware.\n"
 msgstr "Error - unable to download firmware.\n"
 
-#: Main.py:190 Main.py:216 Main.py:342
+#: Main.py:139 Main.py:286
+msgid "Downloaded successfully!\n"
+msgstr "Downloaded successfully!\n"
+
+#: Main.py:168 Main.py:317 Main.py:343
 msgid "Invalid device family detected."
 msgstr "Invalid device family detected."
 
-#: Main.py:240
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+#: Main.py:206
+msgid "Invalid flash method detected. Update BrewFlasher and try again."
+msgstr "Invalid flash method detected. Update BrewFlasher and try again."
 
-#: Main.py:265
+#: Main.py:212 Main.py:392
 msgid "Performing 1200 bps touch"
 msgstr "Performing 1200 bps touch"
 
-#: Main.py:275
+#: Main.py:215 Main.py:396
+msgid "...done"
+msgstr "...done"
+
+#: Main.py:219 Main.py:403
 msgid "...unable to perform 1200bps touch."
 msgstr "...unable to perform 1200bps touch."
 
-#: Main.py:278
+#: Main.py:222 Main.py:406
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 
-#: Main.py:280 Main.py:301 Main.py:334
+#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternatively, you may need to manually set the device into 'flash' mode."
 
-#: Main.py:282 Main.py:303 Main.py:336
+#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:295 Main.py:328
+#: Main.py:239 Main.py:423
 msgid "Firmware flashing FAILED. esptool.py raised an error."
 msgstr "Firmware flashing FAILED. esptool.py raised an error."
 
-#: Main.py:297 Main.py:330
+#: Main.py:241 Main.py:425
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Try flashing again, or try flashing with a slower speed."
 
-#: Main.py:312 Main.py:425
-msgid "Avrdude was not found. Arduino firmware cannot be flashed."
-msgstr "Avrdude was not found. Arduino firmware cannot be flashed."
-
-#: Main.py:313 Main.py:426
-msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
-msgstr "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
-
-#: Main.py:347
+#: Main.py:253 Main.py:439
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 
-#: Main.py:419
+#: Main.py:367
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+
+#: Main.py:510
 msgid "Connect your device"
 msgstr "Connect your device"
 
-#: Main.py:421
+#: Main.py:512
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 
-#: Main.py:525
+#: Main.py:516
+msgid "Avrdude was not found. Arduino firmware cannot be flashed."
+msgstr "Avrdude was not found. Arduino firmware cannot be flashed."
+
+#: Main.py:517
+msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
+msgstr "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
+
+#: Main.py:610
 msgid "Reload serial device list"
 msgstr "Reload serial device list"
 
-#: Main.py:597
+#: Main.py:678
 msgid "no"
 msgstr "no"
 
-#: Main.py:598
+#: Main.py:679
 msgid "yes, wipes all data"
 msgstr "yes, wipes all data"
 
-#: Main.py:600
+#: Main.py:681
 msgid "Download Firmware and Flash Controller"
 msgstr "Download Firmware and Flash Controller"
 
-#: Main.py:610
+#: Main.py:691
 msgid "Serial port"
 msgstr "Serial port"
 
-#: Main.py:611
+#: Main.py:692
 msgid "Project"
 msgstr "Project"
 
-#: Main.py:612
+#: Main.py:693
 msgid "Device Family"
 msgstr "Device Family"
 
-#: Main.py:613
+#: Main.py:694
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:614
+#: Main.py:695
 msgid "Baud rate"
 msgstr "Baud rate"
 
-#: Main.py:636
+#: Main.py:717
 msgid "Erase flash"
 msgstr "Erase flash"
 
-#: Main.py:637
+#: Main.py:718
 msgid "Console"
 msgstr "Console"
 
-#: Main.py:675
+#: Main.py:756
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Welcome to BrewFlasher {version}"
 
-#: Main.py:685
+#: Main.py:766
 msgid "Exit BrewFlasher"
 msgstr "Exit BrewFlasher"
 
-#: Main.py:692
+#: Main.py:773
 msgid "About"
 msgstr "About"
 

--- a/locales/en/LC_MESSAGES/brewflasher.po
+++ b/locales/en/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-11 21:29-0400\n"
-"PO-Revision-Date: 2023-08-12 01:43\n"
+"POT-Creation-Date: 2023-08-11 22:41-0400\n"
+"PO-Revision-Date: 2023-08-12 02:41\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
 "MIME-Version: 1.0\n"
@@ -26,153 +26,153 @@ msgstr "Auto-select"
 msgid "(first port with Espressif device)"
 msgstr "(first port with Espressif device)"
 
-#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
+#: Main.py:128
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Must select the project, device family, and firmware to flash before flashing."
 
-#: Main.py:130 Main.py:278
+#: Main.py:131
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verifying firmware list is up-to-date before downloading..."
 
-#: Main.py:132 Main.py:280
+#: Main.py:133
 msgid "Firmware list is not up to date."
 msgstr "Firmware list is not up to date."
 
-#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
+#: Main.py:133 Main.py:169
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Relaunch BrewFlasher and try again."
 
-#: Main.py:135 Main.py:283
+#: Main.py:136
 msgid "Downloading firmware..."
 msgstr "Downloading firmware..."
 
-#: Main.py:137 Main.py:288
+#: Main.py:138
 msgid "Error - unable to download firmware.\n"
 msgstr "Error - unable to download firmware.\n"
 
-#: Main.py:139 Main.py:286
+#: Main.py:140
 msgid "Downloaded successfully!\n"
 msgstr "Downloaded successfully!\n"
 
-#: Main.py:168 Main.py:317 Main.py:343
+#: Main.py:169
 msgid "Invalid device family detected."
 msgstr "Invalid device family detected."
 
-#: Main.py:206
+#: Main.py:189
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+
+#: Main.py:223
 msgid "Invalid flash method detected. Update BrewFlasher and try again."
 msgstr "Invalid flash method detected. Update BrewFlasher and try again."
 
-#: Main.py:212 Main.py:392
+#: Main.py:229
 msgid "Performing 1200 bps touch"
 msgstr "Performing 1200 bps touch"
 
-#: Main.py:215 Main.py:396
+#: Main.py:232
 msgid "...done"
 msgstr "...done"
 
-#: Main.py:219 Main.py:403
+#: Main.py:236
 msgid "...unable to perform 1200bps touch."
 msgstr "...unable to perform 1200bps touch."
 
-#: Main.py:222 Main.py:406
+#: Main.py:239
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 
-#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
+#: Main.py:241 Main.py:262
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternatively, you may need to manually set the device into 'flash' mode."
 
-#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
+#: Main.py:243 Main.py:264
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:239 Main.py:423
-msgid "Firmware flashing FAILED. esptool.py raised an error."
-msgstr "Firmware flashing FAILED. esptool.py raised an error."
+#: Main.py:256
+msgid "Firmware flashing FAILED. {tool} raised an error."
+msgstr "Firmware flashing FAILED. {tool} raised an error."
 
-#: Main.py:241 Main.py:425
+#: Main.py:258
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Try flashing again, or try flashing with a slower speed."
 
-#: Main.py:253 Main.py:439
+#: Main.py:270
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 
-#: Main.py:367
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-
-#: Main.py:510
+#: Main.py:355
 msgid "Connect your device"
 msgstr "Connect your device"
 
-#: Main.py:512
+#: Main.py:357
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 
-#: Main.py:516
+#: Main.py:361
 msgid "Avrdude was not found. Arduino firmware cannot be flashed."
 msgstr "Avrdude was not found. Arduino firmware cannot be flashed."
 
-#: Main.py:517
+#: Main.py:362
 msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
 msgstr "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
 
-#: Main.py:610
+#: Main.py:455
 msgid "Reload serial device list"
 msgstr "Reload serial device list"
 
-#: Main.py:678
+#: Main.py:523
 msgid "no"
 msgstr "no"
 
-#: Main.py:679
+#: Main.py:524
 msgid "yes, wipes all data"
 msgstr "yes, wipes all data"
 
-#: Main.py:681
+#: Main.py:526
 msgid "Download Firmware and Flash Controller"
 msgstr "Download Firmware and Flash Controller"
 
-#: Main.py:691
+#: Main.py:536
 msgid "Serial port"
 msgstr "Serial port"
 
-#: Main.py:692
+#: Main.py:537
 msgid "Project"
 msgstr "Project"
 
-#: Main.py:693
+#: Main.py:538
 msgid "Device Family"
 msgstr "Device Family"
 
-#: Main.py:694
+#: Main.py:539
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:695
+#: Main.py:540
 msgid "Baud rate"
 msgstr "Baud rate"
 
-#: Main.py:717
+#: Main.py:562
 msgid "Erase flash"
 msgstr "Erase flash"
 
-#: Main.py:718
+#: Main.py:563
 msgid "Console"
 msgstr "Console"
 
-#: Main.py:756
+#: Main.py:601
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Welcome to BrewFlasher {version}"
 
-#: Main.py:766
+#: Main.py:611
 msgid "Exit BrewFlasher"
 msgstr "Exit BrewFlasher"
 
-#: Main.py:773
+#: Main.py:618
 msgid "About"
 msgstr "About"
 

--- a/locales/es/LC_MESSAGES/brewflasher.po
+++ b/locales/es/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-11 21:29-0400\n"
-"PO-Revision-Date: 2023-08-12 01:43\n"
+"POT-Creation-Date: 2023-08-11 22:41-0400\n"
+"PO-Revision-Date: 2023-08-12 02:41\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
 "MIME-Version: 1.0\n"
@@ -26,153 +26,153 @@ msgstr "Autoseleccionar"
 msgid "(first port with Espressif device)"
 msgstr "(primer puerto con dispositivo Espressif)"
 
-#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
+#: Main.py:128
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Debe seleccionar el proyecto, la familia de dispositivos y el firmware a flashear antes de realizar el flasheo."
 
-#: Main.py:130 Main.py:278
+#: Main.py:131
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verificando que la lista de firmware esté actualizada antes de descargar..."
 
-#: Main.py:132 Main.py:280
+#: Main.py:133
 msgid "Firmware list is not up to date."
 msgstr "La lista de firmware no está actualizada."
 
-#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
+#: Main.py:133 Main.py:169
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Vuelve a abrir BrewFlasher e intente nuevamente."
 
-#: Main.py:135 Main.py:283
+#: Main.py:136
 msgid "Downloading firmware..."
 msgstr "Descargando firmware..."
 
-#: Main.py:137 Main.py:288
+#: Main.py:138
 msgid "Error - unable to download firmware.\n"
 msgstr "Error - no se pudo descargar el firmware.\n"
 
-#: Main.py:139 Main.py:286
+#: Main.py:140
 msgid "Downloaded successfully!\n"
 msgstr "¡Descarga completa!\n"
 
-#: Main.py:168 Main.py:317 Main.py:343
+#: Main.py:169
 msgid "Invalid device family detected."
 msgstr "Se ha detectado una familia de dispositivos inválida."
 
-#: Main.py:206
+#: Main.py:189
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "ERROR - No se puede seleccionar automáticamente el puerto serie para esta familia de dispositivos. Por favor, seleccione explícitamente el dispositivo correcto para continuar."
+
+#: Main.py:223
 msgid "Invalid flash method detected. Update BrewFlasher and try again."
 msgstr "Se detectó un método de flasheo inválido. Actualiza BrewFlasher e intenta nuevamente."
 
-#: Main.py:212 Main.py:392
+#: Main.py:229
 msgid "Performing 1200 bps touch"
 msgstr "Realizando toque de 1200 bps"
 
-#: Main.py:215 Main.py:396
+#: Main.py:232
 msgid "...done"
 msgstr "...hecho"
 
-#: Main.py:219 Main.py:403
+#: Main.py:236
 msgid "...unable to perform 1200bps touch."
 msgstr "...no se puede tocar 1200bps."
 
-#: Main.py:222 Main.py:406
+#: Main.py:239
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Asegúrese de haber seleccionado el puerto serie correcto (la opción de selección automática no funcionará para este chip) e intente nuevamente."
 
-#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
+#: Main.py:241 Main.py:262
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternativamente, puede que necesite configurar manualmente el dispositivo en modo 'flash'."
 
-#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
+#: Main.py:243 Main.py:264
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "Para obtener instrucciones sobre cómo hacerlo, consulte este sitio web:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:239 Main.py:423
-msgid "Firmware flashing FAILED. esptool.py raised an error."
-msgstr "El flashing del firmware FALLÓ. esptool.py ha producido un error."
+#: Main.py:256
+msgid "Firmware flashing FAILED. {tool} raised an error."
+msgstr "El flashing del firmware FALLÓ. {tool} ha producido un error."
 
-#: Main.py:241 Main.py:425
+#: Main.py:258
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Intente flashear de nuevo, o intente flashear con una velocidad más lenta."
 
-#: Main.py:253 Main.py:439
+#: Main.py:270
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware flasheado exitosamente. Reinicie el dispositivo para volver al modo de arranque normal."
 
-#: Main.py:367
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "ERROR - No se puede seleccionar automáticamente el puerto serie para esta familia de dispositivos. Por favor, seleccione explícitamente el dispositivo correcto para continuar."
-
-#: Main.py:510
+#: Main.py:355
 msgid "Connect your device"
 msgstr "Conecte su dispositivo"
 
-#: Main.py:512
+#: Main.py:357
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Si eligió la función de autoselección de puerto serie puede que necesite desactivar Bluetooth"
 
-#: Main.py:516
+#: Main.py:361
 msgid "Avrdude was not found. Arduino firmware cannot be flashed."
 msgstr "Avrdude no fue encontrado. No se puede flashear el firmware de Arduino."
 
-#: Main.py:517
+#: Main.py:362
 msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
 msgstr "Para instalar Avrdude, sigue las instrucciones en https://github.com/avrdudes/avrdude/"
 
-#: Main.py:610
+#: Main.py:455
 msgid "Reload serial device list"
 msgstr "Recargar lista de dispositivos seriales"
 
-#: Main.py:678
+#: Main.py:523
 msgid "no"
 msgstr "no"
 
-#: Main.py:679
+#: Main.py:524
 msgid "yes, wipes all data"
 msgstr "sí, borra todos los datos"
 
-#: Main.py:681
+#: Main.py:526
 msgid "Download Firmware and Flash Controller"
 msgstr "Descargar Firmware y Flash Controller"
 
-#: Main.py:691
+#: Main.py:536
 msgid "Serial port"
 msgstr "Puerto serie"
 
-#: Main.py:692
+#: Main.py:537
 msgid "Project"
 msgstr "Proyecto"
 
-#: Main.py:693
+#: Main.py:538
 msgid "Device Family"
 msgstr "Familia de dispositivos"
 
-#: Main.py:694
+#: Main.py:539
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:695
+#: Main.py:540
 msgid "Baud rate"
 msgstr "Velocidad de transmisión en baudios"
 
-#: Main.py:717
+#: Main.py:562
 msgid "Erase flash"
 msgstr "Borrar flash"
 
-#: Main.py:718
+#: Main.py:563
 msgid "Console"
 msgstr "Consola"
 
-#: Main.py:756
+#: Main.py:601
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Bienvenido a BrewFlasher {version}"
 
-#: Main.py:766
+#: Main.py:611
 msgid "Exit BrewFlasher"
 msgstr "Salir de BrewFlasher"
 
-#: Main.py:773
+#: Main.py:618
 msgid "About"
 msgstr "Acerca De"
 

--- a/locales/es/LC_MESSAGES/brewflasher.po
+++ b/locales/es/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-10 20:18-0400\n"
-"PO-Revision-Date: 2023-08-11 01:01\n"
+"POT-Creation-Date: 2023-08-11 21:29-0400\n"
+"PO-Revision-Date: 2023-08-12 01:43\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
 "MIME-Version: 1.0\n"
@@ -26,145 +26,153 @@ msgstr "Autoseleccionar"
 msgid "(first port with Espressif device)"
 msgstr "(primer puerto con dispositivo Espressif)"
 
-#: Main.py:138 Main.py:141 Main.py:144
+#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Debe seleccionar el proyecto, la familia de dispositivos y el firmware a flashear antes de realizar el flasheo."
 
-#: Main.py:147
+#: Main.py:130 Main.py:278
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verificando que la lista de firmware esté actualizada antes de descargar..."
 
-#: Main.py:149
+#: Main.py:132 Main.py:280
 msgid "Firmware list is not up to date."
 msgstr "La lista de firmware no está actualizada."
 
-#: Main.py:149 Main.py:190 Main.py:216 Main.py:342
+#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Vuelve a abrir BrewFlasher e intente nuevamente."
 
-#: Main.py:152
+#: Main.py:135 Main.py:283
 msgid "Downloading firmware..."
 msgstr "Descargando firmware..."
 
-#: Main.py:155
-msgid "Downloaded successfully!\n"
-msgstr "¡Descarga completa!\n"
-
-#: Main.py:157
+#: Main.py:137 Main.py:288
 msgid "Error - unable to download firmware.\n"
 msgstr "Error - no se pudo descargar el firmware.\n"
 
-#: Main.py:190 Main.py:216 Main.py:342
+#: Main.py:139 Main.py:286
+msgid "Downloaded successfully!\n"
+msgstr "¡Descarga completa!\n"
+
+#: Main.py:168 Main.py:317 Main.py:343
 msgid "Invalid device family detected."
 msgstr "Se ha detectado una familia de dispositivos inválida."
 
-#: Main.py:240
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "ERROR - No se puede seleccionar automáticamente el puerto serie para esta familia de dispositivos. Por favor, seleccione explícitamente el dispositivo correcto para continuar."
+#: Main.py:206
+msgid "Invalid flash method detected. Update BrewFlasher and try again."
+msgstr "Se detectó un método de flasheo inválido. Actualiza BrewFlasher e intenta nuevamente."
 
-#: Main.py:265
+#: Main.py:212 Main.py:392
 msgid "Performing 1200 bps touch"
 msgstr "Realizando toque de 1200 bps"
 
-#: Main.py:275
+#: Main.py:215 Main.py:396
+msgid "...done"
+msgstr "...hecho"
+
+#: Main.py:219 Main.py:403
 msgid "...unable to perform 1200bps touch."
 msgstr "...no se puede tocar 1200bps."
 
-#: Main.py:278
+#: Main.py:222 Main.py:406
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Asegúrese de haber seleccionado el puerto serie correcto (la opción de selección automática no funcionará para este chip) e intente nuevamente."
 
-#: Main.py:280 Main.py:301 Main.py:334
+#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternativamente, puede que necesite configurar manualmente el dispositivo en modo 'flash'."
 
-#: Main.py:282 Main.py:303 Main.py:336
+#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "Para obtener instrucciones sobre cómo hacerlo, consulte este sitio web:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:295 Main.py:328
+#: Main.py:239 Main.py:423
 msgid "Firmware flashing FAILED. esptool.py raised an error."
 msgstr "El flashing del firmware FALLÓ. esptool.py ha producido un error."
 
-#: Main.py:297 Main.py:330
+#: Main.py:241 Main.py:425
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Intente flashear de nuevo, o intente flashear con una velocidad más lenta."
 
-#: Main.py:312 Main.py:425
-msgid "Avrdude was not found. Arduino firmware cannot be flashed."
-msgstr "Avrdude no fue encontrado. No se puede flashear el firmware de Arduino."
-
-#: Main.py:313 Main.py:426
-msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
-msgstr "Para instalar Avrdude, sigue las instrucciones en https://github.com/avrdudes/avrdude/"
-
-#: Main.py:347
+#: Main.py:253 Main.py:439
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware flasheado exitosamente. Reinicie el dispositivo para volver al modo de arranque normal."
 
-#: Main.py:419
+#: Main.py:367
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "ERROR - No se puede seleccionar automáticamente el puerto serie para esta familia de dispositivos. Por favor, seleccione explícitamente el dispositivo correcto para continuar."
+
+#: Main.py:510
 msgid "Connect your device"
 msgstr "Conecte su dispositivo"
 
-#: Main.py:421
+#: Main.py:512
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Si eligió la función de autoselección de puerto serie puede que necesite desactivar Bluetooth"
 
-#: Main.py:525
+#: Main.py:516
+msgid "Avrdude was not found. Arduino firmware cannot be flashed."
+msgstr "Avrdude no fue encontrado. No se puede flashear el firmware de Arduino."
+
+#: Main.py:517
+msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
+msgstr "Para instalar Avrdude, sigue las instrucciones en https://github.com/avrdudes/avrdude/"
+
+#: Main.py:610
 msgid "Reload serial device list"
 msgstr "Recargar lista de dispositivos seriales"
 
-#: Main.py:597
+#: Main.py:678
 msgid "no"
 msgstr "no"
 
-#: Main.py:598
+#: Main.py:679
 msgid "yes, wipes all data"
 msgstr "sí, borra todos los datos"
 
-#: Main.py:600
+#: Main.py:681
 msgid "Download Firmware and Flash Controller"
 msgstr "Descargar Firmware y Flash Controller"
 
-#: Main.py:610
+#: Main.py:691
 msgid "Serial port"
 msgstr "Puerto serie"
 
-#: Main.py:611
+#: Main.py:692
 msgid "Project"
 msgstr "Proyecto"
 
-#: Main.py:612
+#: Main.py:693
 msgid "Device Family"
 msgstr "Familia de dispositivos"
 
-#: Main.py:613
+#: Main.py:694
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:614
+#: Main.py:695
 msgid "Baud rate"
 msgstr "Velocidad de transmisión en baudios"
 
-#: Main.py:636
+#: Main.py:717
 msgid "Erase flash"
 msgstr "Borrar flash"
 
-#: Main.py:637
+#: Main.py:718
 msgid "Console"
 msgstr "Consola"
 
-#: Main.py:675
+#: Main.py:756
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Bienvenido a BrewFlasher {version}"
 
-#: Main.py:685
+#: Main.py:766
 msgid "Exit BrewFlasher"
 msgstr "Salir de BrewFlasher"
 
-#: Main.py:692
+#: Main.py:773
 msgid "About"
 msgstr "Acerca De"
 

--- a/locales/no/LC_MESSAGES/brewflasher.po
+++ b/locales/no/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-11 21:29-0400\n"
-"PO-Revision-Date: 2023-08-12 01:43\n"
+"POT-Creation-Date: 2023-08-11 22:41-0400\n"
+"PO-Revision-Date: 2023-08-12 02:41\n"
 "Last-Translator: \n"
 "Language-Team: Norwegian\n"
 "MIME-Version: 1.0\n"
@@ -26,153 +26,153 @@ msgstr "Automerking"
 msgid "(first port with Espressif device)"
 msgstr "(første port med Espressif enhet)"
 
-#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
+#: Main.py:128
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Må velge prosjekt, enhetsfamilie og firmware før flashing."
 
-#: Main.py:130 Main.py:278
+#: Main.py:131
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verifiserer firmwarelisten er oppdatert før nedlasting..."
 
-#: Main.py:132 Main.py:280
+#: Main.py:133
 msgid "Firmware list is not up to date."
 msgstr "Firmware listen er ikke oppdatert."
 
-#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
+#: Main.py:133 Main.py:169
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Restart BrewFlasher og prøv igjen."
 
-#: Main.py:135 Main.py:283
+#: Main.py:136
 msgid "Downloading firmware..."
 msgstr "Laster ned firmware..."
 
-#: Main.py:137 Main.py:288
+#: Main.py:138
 msgid "Error - unable to download firmware.\n"
 msgstr "Feil - kunne ikke laste ned firmware.\n"
 
-#: Main.py:139 Main.py:286
+#: Main.py:140
 msgid "Downloaded successfully!\n"
 msgstr "Nedlasting vellykket!\n"
 
-#: Main.py:168 Main.py:317 Main.py:343
+#: Main.py:169
 msgid "Invalid device family detected."
 msgstr "Ugyldig enhetsfamilie oppdaget."
 
-#: Main.py:206
+#: Main.py:189
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "FEIL - Kan ikke automatisk velge seriell porten for denne enhetsfamilien. Vennligst velg riktig enhet for å fortsette."
+
+#: Main.py:223
 msgid "Invalid flash method detected. Update BrewFlasher and try again."
 msgstr "Ugyldig flash-metode oppdaget. Oppdater BrewFlasher og prøv igjen."
 
-#: Main.py:212 Main.py:392
+#: Main.py:229
 msgid "Performing 1200 bps touch"
 msgstr "Utfører 1200 bps test"
 
-#: Main.py:215 Main.py:396
+#: Main.py:232
 msgid "...done"
 msgstr "...ferdig"
 
-#: Main.py:219 Main.py:403
+#: Main.py:236
 msgid "...unable to perform 1200bps touch."
 msgstr "...kan ikke gjøre 1200bps test."
 
-#: Main.py:222 Main.py:406
+#: Main.py:239
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Sørg for at du har valgt riktig seriell port (automerking fungerer ikke for denne chipen) og prøv igjen."
 
-#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
+#: Main.py:241 Main.py:262
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternativt kan du manuelt sette enheten i \"flash\" modus."
 
-#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
+#: Main.py:243 Main.py:264
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "For instruksjoner om hvordan du skal gjøre dette, se denne siden:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:239 Main.py:423
-msgid "Firmware flashing FAILED. esptool.py raised an error."
-msgstr "Firmware flashing FEILET. esptool.py utløste en feil."
+#: Main.py:256
+msgid "Firmware flashing FAILED. {tool} raised an error."
+msgstr "Firmware flashing FEILET. {tool} utløste en feil."
 
-#: Main.py:241 Main.py:425
+#: Main.py:258
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Prøv å flashe igjen, eller prøv å flashe med en lavere hastighet."
 
-#: Main.py:253 Main.py:439
+#: Main.py:270
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware flashet. Reset enheten for å bytte tilbake til normal boot modus."
 
-#: Main.py:367
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "FEIL - Kan ikke automatisk velge seriell porten for denne enhetsfamilien. Vennligst velg riktig enhet for å fortsette."
-
-#: Main.py:510
+#: Main.py:355
 msgid "Connect your device"
 msgstr "Koble til enheten din"
 
-#: Main.py:512
+#: Main.py:357
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Hvis du valgte seriell port automerk funksjonen må du muligens slå av Bluetooth"
 
-#: Main.py:516
+#: Main.py:361
 msgid "Avrdude was not found. Arduino firmware cannot be flashed."
 msgstr "Avrdude ble ikke funnet. Arduino-firmware kan ikke flashes."
 
-#: Main.py:517
+#: Main.py:362
 msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
 msgstr "For å installere Avrdude, følg instruksjonene på https://github.com/avrdudes/avrdude/"
 
-#: Main.py:610
+#: Main.py:455
 msgid "Reload serial device list"
 msgstr "Oppdater seriell enhetsliste"
 
-#: Main.py:678
+#: Main.py:523
 msgid "no"
 msgstr "nei"
 
-#: Main.py:679
+#: Main.py:524
 msgid "yes, wipes all data"
 msgstr "ja, sletter all data"
 
-#: Main.py:681
+#: Main.py:526
 msgid "Download Firmware and Flash Controller"
 msgstr "Last ned Firmware og Flash-kontroller"
 
-#: Main.py:691
+#: Main.py:536
 msgid "Serial port"
 msgstr "Seriell port"
 
-#: Main.py:692
+#: Main.py:537
 msgid "Project"
 msgstr "Prosjekt"
 
-#: Main.py:693
+#: Main.py:538
 msgid "Device Family"
 msgstr "Enhetsfamilie"
 
-#: Main.py:694
+#: Main.py:539
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:695
+#: Main.py:540
 msgid "Baud rate"
 msgstr "Overføringshastighet"
 
-#: Main.py:717
+#: Main.py:562
 msgid "Erase flash"
 msgstr "Slett flash"
 
-#: Main.py:718
+#: Main.py:563
 msgid "Console"
 msgstr "Konsoll"
 
-#: Main.py:756
+#: Main.py:601
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Velkommen til BrewFlasher {version}"
 
-#: Main.py:766
+#: Main.py:611
 msgid "Exit BrewFlasher"
 msgstr "Avslutt BrewFlasher"
 
-#: Main.py:773
+#: Main.py:618
 msgid "About"
 msgstr "Om"
 

--- a/locales/no/LC_MESSAGES/brewflasher.po
+++ b/locales/no/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-10 20:18-0400\n"
-"PO-Revision-Date: 2023-08-11 01:01\n"
+"POT-Creation-Date: 2023-08-11 21:29-0400\n"
+"PO-Revision-Date: 2023-08-12 01:43\n"
 "Last-Translator: \n"
 "Language-Team: Norwegian\n"
 "MIME-Version: 1.0\n"
@@ -26,145 +26,153 @@ msgstr "Automerking"
 msgid "(first port with Espressif device)"
 msgstr "(første port med Espressif enhet)"
 
-#: Main.py:138 Main.py:141 Main.py:144
+#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Må velge prosjekt, enhetsfamilie og firmware før flashing."
 
-#: Main.py:147
+#: Main.py:130 Main.py:278
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verifiserer firmwarelisten er oppdatert før nedlasting..."
 
-#: Main.py:149
+#: Main.py:132 Main.py:280
 msgid "Firmware list is not up to date."
 msgstr "Firmware listen er ikke oppdatert."
 
-#: Main.py:149 Main.py:190 Main.py:216 Main.py:342
+#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Restart BrewFlasher og prøv igjen."
 
-#: Main.py:152
+#: Main.py:135 Main.py:283
 msgid "Downloading firmware..."
 msgstr "Laster ned firmware..."
 
-#: Main.py:155
-msgid "Downloaded successfully!\n"
-msgstr "Nedlasting vellykket!\n"
-
-#: Main.py:157
+#: Main.py:137 Main.py:288
 msgid "Error - unable to download firmware.\n"
 msgstr "Feil - kunne ikke laste ned firmware.\n"
 
-#: Main.py:190 Main.py:216 Main.py:342
+#: Main.py:139 Main.py:286
+msgid "Downloaded successfully!\n"
+msgstr "Nedlasting vellykket!\n"
+
+#: Main.py:168 Main.py:317 Main.py:343
 msgid "Invalid device family detected."
 msgstr "Ugyldig enhetsfamilie oppdaget."
 
-#: Main.py:240
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "FEIL - Kan ikke automatisk velge seriell porten for denne enhetsfamilien. Vennligst velg riktig enhet for å fortsette."
+#: Main.py:206
+msgid "Invalid flash method detected. Update BrewFlasher and try again."
+msgstr "Ugyldig flash-metode oppdaget. Oppdater BrewFlasher og prøv igjen."
 
-#: Main.py:265
+#: Main.py:212 Main.py:392
 msgid "Performing 1200 bps touch"
-msgstr "Utfører 1200 bps touch"
+msgstr "Utfører 1200 bps test"
 
-#: Main.py:275
+#: Main.py:215 Main.py:396
+msgid "...done"
+msgstr "...ferdig"
+
+#: Main.py:219 Main.py:403
 msgid "...unable to perform 1200bps touch."
-msgstr "...kan ikke gjøre 1200bps touch."
+msgstr "...kan ikke gjøre 1200bps test."
 
-#: Main.py:278
+#: Main.py:222 Main.py:406
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Sørg for at du har valgt riktig seriell port (automerking fungerer ikke for denne chipen) og prøv igjen."
 
-#: Main.py:280 Main.py:301 Main.py:334
+#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Alternativt kan du manuelt sette enheten i \"flash\" modus."
 
-#: Main.py:282 Main.py:303 Main.py:336
+#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "For instruksjoner om hvordan du skal gjøre dette, se denne siden:\n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:295 Main.py:328
+#: Main.py:239 Main.py:423
 msgid "Firmware flashing FAILED. esptool.py raised an error."
 msgstr "Firmware flashing FEILET. esptool.py utløste en feil."
 
-#: Main.py:297 Main.py:330
+#: Main.py:241 Main.py:425
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Prøv å flashe igjen, eller prøv å flashe med en lavere hastighet."
 
-#: Main.py:312 Main.py:425
-msgid "Avrdude was not found. Arduino firmware cannot be flashed."
-msgstr "Avrdude ble ikke funnet. Arduino-firmware kan ikke flashes."
-
-#: Main.py:313 Main.py:426
-msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
-msgstr "For å installere Avrdude, følg instruksjonene på https://github.com/avrdudes/avrdude/"
-
-#: Main.py:347
+#: Main.py:253 Main.py:439
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Firmware flashet. Reset enheten for å bytte tilbake til normal boot modus."
 
-#: Main.py:419
+#: Main.py:367
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "FEIL - Kan ikke automatisk velge seriell porten for denne enhetsfamilien. Vennligst velg riktig enhet for å fortsette."
+
+#: Main.py:510
 msgid "Connect your device"
 msgstr "Koble til enheten din"
 
-#: Main.py:421
+#: Main.py:512
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Hvis du valgte seriell port automerk funksjonen må du muligens slå av Bluetooth"
 
-#: Main.py:525
+#: Main.py:516
+msgid "Avrdude was not found. Arduino firmware cannot be flashed."
+msgstr "Avrdude ble ikke funnet. Arduino-firmware kan ikke flashes."
+
+#: Main.py:517
+msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
+msgstr "For å installere Avrdude, følg instruksjonene på https://github.com/avrdudes/avrdude/"
+
+#: Main.py:610
 msgid "Reload serial device list"
 msgstr "Oppdater seriell enhetsliste"
 
-#: Main.py:597
+#: Main.py:678
 msgid "no"
 msgstr "nei"
 
-#: Main.py:598
+#: Main.py:679
 msgid "yes, wipes all data"
 msgstr "ja, sletter all data"
 
-#: Main.py:600
+#: Main.py:681
 msgid "Download Firmware and Flash Controller"
 msgstr "Last ned Firmware og Flash-kontroller"
 
-#: Main.py:610
+#: Main.py:691
 msgid "Serial port"
 msgstr "Seriell port"
 
-#: Main.py:611
+#: Main.py:692
 msgid "Project"
 msgstr "Prosjekt"
 
-#: Main.py:612
+#: Main.py:693
 msgid "Device Family"
 msgstr "Enhetsfamilie"
 
-#: Main.py:613
+#: Main.py:694
 msgid "Firmware"
 msgstr "Firmware"
 
-#: Main.py:614
+#: Main.py:695
 msgid "Baud rate"
 msgstr "Overføringshastighet"
 
-#: Main.py:636
+#: Main.py:717
 msgid "Erase flash"
 msgstr "Slett flash"
 
-#: Main.py:637
+#: Main.py:718
 msgid "Console"
 msgstr "Konsoll"
 
-#: Main.py:675
+#: Main.py:756
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Velkommen til BrewFlasher {version}"
 
-#: Main.py:685
+#: Main.py:766
 msgid "Exit BrewFlasher"
 msgstr "Avslutt BrewFlasher"
 
-#: Main.py:692
+#: Main.py:773
 msgid "About"
 msgstr "Om"
 

--- a/locales/sv/LC_MESSAGES/brewflasher.po
+++ b/locales/sv/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-10 20:18-0400\n"
-"PO-Revision-Date: 2023-08-11 01:01\n"
+"POT-Creation-Date: 2023-08-11 21:29-0400\n"
+"PO-Revision-Date: 2023-08-12 01:43\n"
 "Last-Translator: \n"
 "Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
@@ -26,145 +26,153 @@ msgstr "Automatiskt val"
 msgid "(first port with Espressif device)"
 msgstr "(första porten med Espressif enhet)"
 
-#: Main.py:138 Main.py:141 Main.py:144
+#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Du måste välja projekt, enhetstyp och mjukvara att programmera innan start."
 
-#: Main.py:147
+#: Main.py:130 Main.py:278
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verfierar att listan på mjukvara är uppdaterad innan nedladdning..."
 
-#: Main.py:149
+#: Main.py:132 Main.py:280
 msgid "Firmware list is not up to date."
 msgstr "Listan med mjukvara är inte uppdaterad."
 
-#: Main.py:149 Main.py:190 Main.py:216 Main.py:342
+#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Starta om BrewFlasher och försök igen."
 
-#: Main.py:152
+#: Main.py:135 Main.py:283
 msgid "Downloading firmware..."
 msgstr "Laddar ned mjukvara..."
 
-#: Main.py:155
-msgid "Downloaded successfully!\n"
-msgstr "Nedladdning lyckades!\n"
-
-#: Main.py:157
+#: Main.py:137 Main.py:288
 msgid "Error - unable to download firmware.\n"
 msgstr "Fel - kan inte ladda ner mjukvara.\n"
 
-#: Main.py:190 Main.py:216 Main.py:342
+#: Main.py:139 Main.py:286
+msgid "Downloaded successfully!\n"
+msgstr "Nedladdning lyckades!\n"
+
+#: Main.py:168 Main.py:317 Main.py:343
 msgid "Invalid device family detected."
 msgstr "Felaktiv enhetstyp detekterades."
 
-#: Main.py:240
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "FEL - Kan inte automatiskt välja seriell port for denna enhetstyp. Var vänlig och välj rätt seriell enhet for att fortsätta."
+#: Main.py:206
+msgid "Invalid flash method detected. Update BrewFlasher and try again."
+msgstr "Ogiltig flashmetod upptäckt. Uppdatera BrewFlasher och försök igen."
 
-#: Main.py:265
+#: Main.py:212 Main.py:392
 msgid "Performing 1200 bps touch"
 msgstr "Utför 1200bps kommando"
 
-#: Main.py:275
+#: Main.py:215 Main.py:396
+msgid "...done"
+msgstr "...klart"
+
+#: Main.py:219 Main.py:403
 msgid "...unable to perform 1200bps touch."
 msgstr "...kunde inte utföra 1200bps kommando."
 
-#: Main.py:278
+#: Main.py:222 Main.py:406
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Säkerställ att du har valt den rätta serialla porten (automatiskt val fungerar inte för denna enhetstyp) och försök igen."
 
-#: Main.py:280 Main.py:301 Main.py:334
+#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Som alternativ kan du sätta enheten i 'programmerings' läge."
 
-#: Main.py:282 Main.py:303 Main.py:336
+#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "För instruktioner om hur man gör detta, kontrollera denna webbplats: \n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:295 Main.py:328
+#: Main.py:239 Main.py:423
 msgid "Firmware flashing FAILED. esptool.py raised an error."
 msgstr "Mjukvaru-uppdatering MISSLYCKADES. esptool.py returnerade ett fel."
 
-#: Main.py:297 Main.py:330
+#: Main.py:241 Main.py:425
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Försök programmera igen, försök med en lägre hastighet."
 
-#: Main.py:312 Main.py:425
-msgid "Avrdude was not found. Arduino firmware cannot be flashed."
-msgstr "Avrdude hittades inte. Arduino firmware kan inte flashas."
-
-#: Main.py:313 Main.py:426
-msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
-msgstr "För att installera Avrdude, följ instruktionerna på https://github.com/avrdudes/avrdude/"
-
-#: Main.py:347
+#: Main.py:253 Main.py:439
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Programmering lyckades. Starta om enheten för att återgå till normalt läge."
 
-#: Main.py:419
+#: Main.py:367
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "FEL - Kan inte automatiskt välja seriell port for denna enhetstyp. Var vänlig och välj rätt seriell enhet for att fortsätta."
+
+#: Main.py:510
 msgid "Connect your device"
 msgstr "Anslut din enhet"
 
-#: Main.py:421
+#: Main.py:512
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Om du väljer en seriell port med automatiskt val så kanske du behöver stänga av Bluetooth"
 
-#: Main.py:525
+#: Main.py:516
+msgid "Avrdude was not found. Arduino firmware cannot be flashed."
+msgstr "Avrdude hittades inte. Arduino firmware kan inte flashas."
+
+#: Main.py:517
+msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
+msgstr "För att installera Avrdude, följ instruktionerna på https://github.com/avrdudes/avrdude/"
+
+#: Main.py:610
 msgid "Reload serial device list"
 msgstr "Ladda om listan med seriella enheter"
 
-#: Main.py:597
+#: Main.py:678
 msgid "no"
 msgstr "nej"
 
-#: Main.py:598
+#: Main.py:679
 msgid "yes, wipes all data"
 msgstr "ja, radera all data"
 
-#: Main.py:600
+#: Main.py:681
 msgid "Download Firmware and Flash Controller"
 msgstr "Ladda ner mjukvara och programmera enhet"
 
-#: Main.py:610
+#: Main.py:691
 msgid "Serial port"
 msgstr "Serieport"
 
-#: Main.py:611
+#: Main.py:692
 msgid "Project"
 msgstr "Projekt"
 
-#: Main.py:612
+#: Main.py:693
 msgid "Device Family"
 msgstr "Enhetstyp"
 
-#: Main.py:613
+#: Main.py:694
 msgid "Firmware"
 msgstr "Mjukvara"
 
-#: Main.py:614
+#: Main.py:695
 msgid "Baud rate"
 msgstr "Seriell hastighet"
 
-#: Main.py:636
+#: Main.py:717
 msgid "Erase flash"
 msgstr "Radera enhet"
 
-#: Main.py:637
+#: Main.py:718
 msgid "Console"
 msgstr "Konsoll"
 
-#: Main.py:675
+#: Main.py:756
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Välkommen till BrewFlasher {version}"
 
-#: Main.py:685
+#: Main.py:766
 msgid "Exit BrewFlasher"
 msgstr "Avsluta BrewFlasher"
 
-#: Main.py:692
+#: Main.py:773
 msgid "About"
 msgstr "Om"
 

--- a/locales/sv/LC_MESSAGES/brewflasher.po
+++ b/locales/sv/LC_MESSAGES/brewflasher.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: brewflasher-desktop\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-11 21:29-0400\n"
-"PO-Revision-Date: 2023-08-12 01:43\n"
+"POT-Creation-Date: 2023-08-11 22:41-0400\n"
+"PO-Revision-Date: 2023-08-12 02:41\n"
 "Last-Translator: \n"
 "Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
@@ -26,153 +26,153 @@ msgstr "Automatiskt val"
 msgid "(first port with Espressif device)"
 msgstr "(första porten med Espressif enhet)"
 
-#: Main.py:127 Main.py:269 Main.py:272 Main.py:275
+#: Main.py:128
 msgid "Must select the project, device family, and firmware to flash before flashing."
 msgstr "Du måste välja projekt, enhetstyp och mjukvara att programmera innan start."
 
-#: Main.py:130 Main.py:278
+#: Main.py:131
 msgid "Verifying firmware list is up-to-date before downloading..."
 msgstr "Verfierar att listan på mjukvara är uppdaterad innan nedladdning..."
 
-#: Main.py:132 Main.py:280
+#: Main.py:133
 msgid "Firmware list is not up to date."
 msgstr "Listan med mjukvara är inte uppdaterad."
 
-#: Main.py:132 Main.py:168 Main.py:280 Main.py:317 Main.py:343
+#: Main.py:133 Main.py:169
 msgid "Relaunch BrewFlasher and try again."
 msgstr "Starta om BrewFlasher och försök igen."
 
-#: Main.py:135 Main.py:283
+#: Main.py:136
 msgid "Downloading firmware..."
 msgstr "Laddar ned mjukvara..."
 
-#: Main.py:137 Main.py:288
+#: Main.py:138
 msgid "Error - unable to download firmware.\n"
 msgstr "Fel - kan inte ladda ner mjukvara.\n"
 
-#: Main.py:139 Main.py:286
+#: Main.py:140
 msgid "Downloaded successfully!\n"
 msgstr "Nedladdning lyckades!\n"
 
-#: Main.py:168 Main.py:317 Main.py:343
+#: Main.py:169
 msgid "Invalid device family detected."
 msgstr "Felaktiv enhetstyp detekterades."
 
-#: Main.py:206
+#: Main.py:189
+msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
+msgstr "FEL - Kan inte automatiskt välja seriell port for denna enhetstyp. Var vänlig och välj rätt seriell enhet for att fortsätta."
+
+#: Main.py:223
 msgid "Invalid flash method detected. Update BrewFlasher and try again."
 msgstr "Ogiltig flashmetod upptäckt. Uppdatera BrewFlasher och försök igen."
 
-#: Main.py:212 Main.py:392
+#: Main.py:229
 msgid "Performing 1200 bps touch"
 msgstr "Utför 1200bps kommando"
 
-#: Main.py:215 Main.py:396
+#: Main.py:232
 msgid "...done"
 msgstr "...klart"
 
-#: Main.py:219 Main.py:403
+#: Main.py:236
 msgid "...unable to perform 1200bps touch."
 msgstr "...kunde inte utföra 1200bps kommando."
 
-#: Main.py:222 Main.py:406
+#: Main.py:239
 msgid "Make sure you have selected the correct serial port (auto-select will not work for this chip) and try again."
 msgstr "Säkerställ att du har valt den rätta serialla porten (automatiskt val fungerar inte för denna enhetstyp) och försök igen."
 
-#: Main.py:224 Main.py:245 Main.py:408 Main.py:429
+#: Main.py:241 Main.py:262
 msgid "Alternatively, you may need to manually set the device into 'flash' mode."
 msgstr "Som alternativ kan du sätta enheten i 'programmerings' läge."
 
-#: Main.py:226 Main.py:247 Main.py:410 Main.py:431
+#: Main.py:243 Main.py:264
 msgid "For instructions on how to do this, check this website:\n"
 "http://www.brewflasher.com/manualflash/"
 msgstr "För instruktioner om hur man gör detta, kontrollera denna webbplats: \n"
 "http://www.brewflasher.com/manualflash/"
 
-#: Main.py:239 Main.py:423
-msgid "Firmware flashing FAILED. esptool.py raised an error."
-msgstr "Mjukvaru-uppdatering MISSLYCKADES. esptool.py returnerade ett fel."
+#: Main.py:256
+msgid "Firmware flashing FAILED. {tool} raised an error."
+msgstr "Mjukvaru-uppdatering MISSLYCKADES. {tool} returnerade ett fel."
 
-#: Main.py:241 Main.py:425
+#: Main.py:258
 msgid "Try flashing again, or try flashing with a slower speed."
 msgstr "Försök programmera igen, försök med en lägre hastighet."
 
-#: Main.py:253 Main.py:439
+#: Main.py:270
 msgid "Firmware successfully flashed. Reset device to switch back to normal boot mode."
 msgstr "Programmering lyckades. Starta om enheten för att återgå till normalt läge."
 
-#: Main.py:367
-msgid "ERROR - Cannot automatically select the serial port for this device family. Please explicitly select the correct device to continue."
-msgstr "FEL - Kan inte automatiskt välja seriell port for denna enhetstyp. Var vänlig och välj rätt seriell enhet for att fortsätta."
-
-#: Main.py:510
+#: Main.py:355
 msgid "Connect your device"
 msgstr "Anslut din enhet"
 
-#: Main.py:512
+#: Main.py:357
 msgid "If you chose the serial port auto-select feature you might need to turn off Bluetooth"
 msgstr "Om du väljer en seriell port med automatiskt val så kanske du behöver stänga av Bluetooth"
 
-#: Main.py:516
+#: Main.py:361
 msgid "Avrdude was not found. Arduino firmware cannot be flashed."
 msgstr "Avrdude hittades inte. Arduino firmware kan inte flashas."
 
-#: Main.py:517
+#: Main.py:362
 msgid "To install Avrdude, follow the instructions at https://github.com/avrdudes/avrdude/"
 msgstr "För att installera Avrdude, följ instruktionerna på https://github.com/avrdudes/avrdude/"
 
-#: Main.py:610
+#: Main.py:455
 msgid "Reload serial device list"
 msgstr "Ladda om listan med seriella enheter"
 
-#: Main.py:678
+#: Main.py:523
 msgid "no"
 msgstr "nej"
 
-#: Main.py:679
+#: Main.py:524
 msgid "yes, wipes all data"
 msgstr "ja, radera all data"
 
-#: Main.py:681
+#: Main.py:526
 msgid "Download Firmware and Flash Controller"
 msgstr "Ladda ner mjukvara och programmera enhet"
 
-#: Main.py:691
+#: Main.py:536
 msgid "Serial port"
 msgstr "Serieport"
 
-#: Main.py:692
+#: Main.py:537
 msgid "Project"
 msgstr "Projekt"
 
-#: Main.py:693
+#: Main.py:538
 msgid "Device Family"
 msgstr "Enhetstyp"
 
-#: Main.py:694
+#: Main.py:539
 msgid "Firmware"
 msgstr "Mjukvara"
 
-#: Main.py:695
+#: Main.py:540
 msgid "Baud rate"
 msgstr "Seriell hastighet"
 
-#: Main.py:717
+#: Main.py:562
 msgid "Erase flash"
 msgstr "Radera enhet"
 
-#: Main.py:718
+#: Main.py:563
 msgid "Console"
 msgstr "Konsoll"
 
-#: Main.py:756
+#: Main.py:601
 msgid "Welcome to BrewFlasher {version}"
 msgstr "Välkommen till BrewFlasher {version}"
 
-#: Main.py:766
+#: Main.py:611
 msgid "Exit BrewFlasher"
 msgstr "Avsluta BrewFlasher"
 
-#: Main.py:773
+#: Main.py:618
 msgid "About"
 msgstr "Om"
 


### PR DESCRIPTION
This PR refactors `brewflasher_com_integration.py` to match the one in use by BrewFlasher CLI edition in order to keep the two in sync. This changes the object definitions to use `@dataclass` syntax for better type hinting and adds the `DeviceFamily` object to the `Firmware` object to simplify some of the logic. 

This PR also refactors out the "flash" action into its own function - `flash_firmware_using_whatever_is_appropriate()` - which (mostly) matches the one in use within BrewFlasher CLI. This should (hopefully!) allow the two to remain in sync, and also adds BrewFlasher CLI's Arduino support to BrewFlasher Desktop.