### PR TITLE
Update to PyInstaller 6

### DIFF
--- a/.github/workflows/build-windows-test.yaml
+++ b/.github/workflows/build-windows-test.yaml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - pyinstaller6
+
+
+jobs:
+  build:
+    runs-on: 'windows-latest'
+
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: actions/setup-python@v4.7.1
+      with:
+        python-version: '3.11'
+
+    - run: pip install -r requirements.txt
+    - name: rebuild bootloader
+      run: |
+        pip install wheel
+        pip uninstall -y pyinstaller
+        git clone https://github.com/pyinstaller/pyinstaller
+        git checkout v6.1.0
+        cd pyinstaller
+        cd bootloader
+        python3 ./waf distclean all
+        cd ..
+        pip install .
+        cd ..
+    - name: compile locales
+      run: python3 compile_languages.py locales
+    - run: pyinstaller --log-level=DEBUG --noconfirm build-on-win.spec
+
+    - name: upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/*

--- a/.github/workflows/build-windows-test.yaml
+++ b/.github/workflows/build-windows-test.yaml
@@ -32,6 +32,6 @@ jobs:
     - run: pyinstaller --log-level=DEBUG --noconfirm build-on-win.spec
 
     - name: upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         path: dist/*

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: 'windows-latest'
 
     steps:
-    - uses: actions/checkout@v3.5.3
-    - uses: actions/setup-python@v4.6.1
+    - uses: actions/checkout@v4.1.1
+    - uses: actions/setup-python@v4.7.1
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - run: pip install -r requirements.txt
     - name: rebuild bootloader
@@ -20,7 +20,7 @@ jobs:
         pip install wheel
         pip uninstall -y pyinstaller
         git clone https://github.com/pyinstaller/pyinstaller
-        git checkout v5.13.0
+        git checkout v6.1.0
         cd pyinstaller
         cd bootloader
         python3 ./waf distclean all
@@ -32,6 +32,6 @@ jobs:
     - run: pyinstaller --log-level=DEBUG --noconfirm build-on-win.spec
 
     - name: upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         path: dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,8 @@ staple.sh
 
 # Exclude the pyinstaller directory (if it's here)
 pyinstaller/
+# Same with the cffi directory
+cffi/
 
 dist-pkg/
 /*.pkg

--- a/build-universal-cffi.sh
+++ b/build-universal-cffi.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+source ./venv/bin/activate
+
+git clone https://github.com/python-cffi/cffi.git
+cd cffi
+git checkout v1.16.0
+
+python3 -m pip install build pytest
+
+# The proper SDKROOT can be found by running `xcrun --sdk macosx --show-sdk-path` -- right now, it's 14.0
+MACOSX_DEPLOYMENT_TARGET='11.0' SDKROOT=macosx14.0 python3 -m build -w .
+python3 -m pip install dist/cffi-*universal2.whl --force-reinstall
+
+# python3 -m pytest .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 esptool==4.6.2
 wxPython==4.2.1
-# Previously PyInstaller 3.4 was used - this has security vulnerabilities per GitHub
-PyInstaller==5.13.0
+PyInstaller==6.1.0
 requests==2.31.0
 pyserial==3.5
 Babel==2.12.1  # For the command line utility so we can build the .mo files

--- a/update_pyinstaller.sh
+++ b/update_pyinstaller.sh
@@ -4,9 +4,10 @@
 # application build. This is required for notarization to work on MacOS (and may prevent security warnings on Windows)
 
 # Note - this command (at least the "pip install" bit) needs to be done from within the virtualenv
+pip uninstall -y pyinstaller
 git clone https://github.com/pyinstaller/pyinstaller.git
 cd pyinstaller
-git checkout v5.13
+git checkout v6.1.0
 cd bootloader
 python ./waf all
 pip install ..


### PR DESCRIPTION
- Updates to PyInstaller 6
- Adds new build script for CFFI in order to enable support for MacOS Universal2 builds
- Updates GitHub actions to latest versions